### PR TITLE
Cleanup

### DIFF
--- a/src/vec.jl
+++ b/src/vec.jl
@@ -271,8 +271,14 @@ function Base.norm{T<:Real}(x::Union{Vec{T},Vec{Complex{T}}}, p::Number)
     v[1]
 end
 
+if VERSION >= v"0.5.0-dev+8353" # JuliaLang/julia#13681
+    import Base.normalize!
+else
+    export normalize!
+end
+
 # computes v = norm(x,2), divides x by v, and returns v
-function Base.normalize!{T<:Scalar}(x::Vec{T})
+function normalize!{T<:Scalar}(x::Vec{T})
     v = Array(T, 1)
     chk(C.VecNormalize(x.p, v))
     v[1]

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -3,15 +3,14 @@ export Vec
 #typealias pVec Ptr{Void} # Vec arguments in Petsc are pointers
 # T is data type
 # VType is type of vector from C.VecType
-type Vec{T, VType} <: AbstractVector{T}
+type Vec{T,VType} <: AbstractVector{T}
     p::C.Vec{T}
     assembling::Bool # whether we are in the middle of assemble(vec) do ..
     insertmode::C.InsertMode # current mode for setindex!
-    comm::MPI.Comm  # communicator this process is defined on
-    vectype::C.VecType
+    comm::MPI.Comm  # communicator this vector is defined on
     function Vec(p::C.Vec{T}; comm=MPI.COMM_SELF)  # default sequantial vector
-        v = new(p, false, C.INSERT_VALUES, comm, VType)
-        settype!(v, VType)  # set the type here to ensure it matches VType
+        v = new(p, false, C.INSERT_VALUES, comm)
+        chk(C.VecSetType(p, VType))  # set the type here to ensure it matches VType
 #        finalizer(v, VecDestroy)
         return v
     end
@@ -23,34 +22,19 @@ function Vec{T}(::Type{T}, vtype::C.VecType=C.VECSEQ; comm=MPI.COMM_SELF)
     Vec{T, vtype}(p[1])
 end
 
-function Vec{T <: Scalar}(::Type{T}, len::Integer, vtype::C.VecType=C.VECSEQ ; comm=MPI.COMM_SELF)
-  p = Array(C.Vec{T}, 1)
-  C.VecCreate(comm, p)
-  vec = Vec{T, vtype}(p[1])
-#  settype!(vec, VType)
-  setsizes!(vec, len)
+function Vec{T<:Scalar}(::Type{T}, len::Integer, vtype::C.VecType=C.VECSEQ;
+                        comm=MPI.COMM_SELF, mlocal::Integer=C.PETSC_DECIDE)
+  vec = Vec(T, vtype; comm=comm)
+  setsizes!(vec, mlocal, m=len)
   vec
 end
 
-
-#=
-Vec(m::Integer;
-    mlocal::Integer=C.PETSC_DECIDE,
-    comm=PETSC_COMM_WORLD,
-    T::C.VecType`="mpi") =
-  setsizes!(settype!(Vec(comm=comm), T), m, mlocal=mlocal)
-=#
-
-
 function VecDestroy(vec::Vec)
-
   tmp = Array(PetscBool, 1)
   C.PetscFinalized(eltype(vec), tmp)
-
   if tmp[1] == 0  # if petsc has not been finalized yet
     C.VecDestroy([vec.p])
   end
-
    # if Petsc has been finalized, let the OS deallocate the memory
 end
 
@@ -59,39 +43,27 @@ function petscview{T}(vec::Vec{T})
   chk(C.VecView(vec.p, viewer))
 end
 
+export gettype, setsizes!
 
+gettype{T,VT}(a::Vec{T,VT}) = VT
 
-export settype!, gettype, setsizes!
-
-function settype!(a::Vec, T::C.VecType)
-    chk(C.VecSetType(a.p, T))
-    a
-end
-
-function gettype(a::Vec)
-    p = Array(C.VecType, 1)  # was UInt8
-#    p[1] = "a"  # need to initialize symbol array to something
-
-    chk(C.VecGetType(a.p, p))
-    p[1]
-end
-
+# todo: this should be a method of Base.resize!
 function setsizes!(x::Vec, mlocal::Integer; m::Integer=C.PETSC_DECIDE)
     chk(C.VecSetSizes(x.p, mlocal, m))
     x
 end
+
 ##########################################################################
-import Base: convert, length, size, similar, copy
 export lengthlocal, sizelocal, localpart
 
-convert(::Type{C.Vec}, v::Vec) = v.p
+Base.convert(::Type{C.Vec}, v::Vec) = v.p
 
-function length(x::Vec)
+function Base.length(x::Vec)
     sz = Array(PetscInt, 1)
     chk(C.VecGetSize(x.p, sz))
     Int(sz[1])
 end
-size(x::Vec) = (length(x),)
+Base.size(x::Vec) = (length(x),)
 
 function lengthlocal(x::Vec)
     sz = Array(PetscInt, 1)
@@ -111,30 +83,34 @@ function localpart(v::Vec)
   return (low[]+1):(high[])
 end
 
-function similar{T, VType}(x::Vec{T, VType})
+function Base.similar{T,VType}(x::Vec{T,VType})
     p = Array(C.Vec{T}, 1)
-    chk(C.VecDuplicate( x.p, p))
-    Vec{T, VType}(p[1])
+    chk(C.VecDuplicate(x.p, p))
+    Vec{T,VType}(p[1])
 end
 
+Base.similar{T}(x::Vec{T}, ::Type{T}) = similar(x)
+Base.similar{T,VType}(x::Vec{T,VType}, T2::Type) =
+    Vec(T2, length(x), VType; comm=x.comm, mlocal=lengthlocal(x))
 
-similar{T}(x::Vec{T}, ::Type{T}) = similar(x)
-function similar{T, VType}(x::Vec{T, VType}, ::Type{T}, len::Int)
-#    println("T = ", T)
-#    println("VType = ", VType)
+function Base.similar{T,VType}(x::Vec{T,VType}, T2::Type, len::Union{Int,Dims})
+    length(len) == 1 || throw(ArgumentError("expecting 1-dimensional size"))
+    len==length(x) && T2==T ? similar(x) : Vec(T2, len, VType; comm=x.comm)
+end
+
+function Base.similar{T,VType}(x::Vec{T,VType}, len::Union{Int,Dims})
+    length(len) == 1 || throw(ArgumentError("expecting 1-dimensional size"))
     len==length(x) ? similar(x) : Vec(T, len, VType; comm=x.comm)
 end
 
-similar{T, DType <: Integer}(x::Vec{T}, t::Type{T}, dims::Tuple{DType}) = similar(x, t, dims[1])
-
-function copy(x::Vec)
+function Base.copy(x::Vec)
     y = similar(x)
     chk(C.VecCopy(x.p, y.p))
     y
 end
 
 ##########################################################################
-import Base: setindex!, fill!, to_index
+import Base: setindex!
 export assemble, isassembled
 
 # for efficient vector assembly, put all calls to x[...] = ... inside
@@ -147,7 +123,6 @@ end
 function AssemblyEnd(x::Vec, t::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
   chk(C.VecAssemblyEnd(x.p))
 end
-
 
 isassembled(x::Vec) = !x.assembling
 # assemble(f::Function, x::Vec) is defined in mat.jl
@@ -167,42 +142,32 @@ function setindex0!{T}(x::Vec{T}, v::Array{T}, i::Array{PetscInt})
     x
 end
 
-function setindex!{T}(x::Vec{T}, v::Number, i::Real)
+function setindex!{T}(x::Vec{T}, v::Number, i::Integer)
     # can't call VecSetValue since that is a static inline function
-#    println("  calling setindex0")
-    setindex0!(x, T[ v ], PetscInt[ to_index(i) - 1 ])
+    setindex0!(x, T[ v ], PetscInt[ i - 1 ])
     v
 end
 
-# what is this function doing?
-#=
-function setindex!{T<: Scalar}(x::Vec{T}, v::Array{T}, I::AbstractArray{T})
-    I0 = PetscInt[ to_index(i)-1 for i in I ]
-    setindex0!(x, v, I0)
-end
-=#
-
-
 # set multiple entries to a single value
-setindex!{T<:Real}(x::Vec, v::Number, I::AbstractArray{T}) = assemble(x) do
+setindex!{T<:Integer}(x::Vec, v::Number, I::AbstractArray{T}) = assemble(x) do
     for i in I
         x[i] = v
     end
     x
 end
 
-function fill!{T}(x::Vec{T}, v::Number)
+function Base.fill!{T}(x::Vec{T}, v::Number)
     chk(C.VecSet(x.p, T(v)))
     return x
 end
 
-function setindex!(x::Vec, v::Number, I::Range{Int})
+function setindex!{T<:Integer}(x::Vec, v::Number, I::Range{T})
     if abs(step(I)) == 1 && minimum(I) == 1 && maximum(I) == length(x)
         fill!(x, v)
         return v
     else
-        # why use invoke here?
-        return invoke(setindex!, (Vec,typeof(v),AbstractVector{Int}), x,v,I)
+        # use invoke here to avoid a recursion loop
+        return invoke(setindex!, (Vec,typeof(v),AbstractVector{T}), x,v,I)
     end
 end
 
@@ -221,7 +186,6 @@ assemble(x) do
     x
 end
 
-
 # logical indexing
 setindex!(A::Vec, x::Number, I::AbstractArray{Bool}) = assemble(A) do
     for i = 1:length(I)
@@ -232,7 +196,7 @@ setindex!(A::Vec, x::Number, I::AbstractArray{Bool}) = assemble(A) do
     A
 end
 for T in (:(Array{T2}),:(AbstractArray{T2})) # avoid method ambiguities
-    @eval setindex!{T2 <: Scalar}(A::Vec, X::$T, I::AbstractArray{Bool}) = assemble(A) do
+    @eval setindex!{T2<:Scalar}(A::Vec, X::$T, I::AbstractArray{Bool}) = assemble(A) do
         c = 1
         for i = 1:length(I)
             if I[i]
@@ -240,7 +204,6 @@ for T in (:(Array{T2}),:(AbstractArray{T2})) # avoid method ambiguities
                 c += 1
             end
         end
-
         A
     end
 end
@@ -255,36 +218,30 @@ function getindex0{T}(x::Vec{T}, i::Vector{PetscInt})
     v
 end
 
-getindex(x::Vec, i::Real) = getindex0(x, PetscInt[to_index(i)-1])[1]
-
-#getindex{T<:Real}(x::Vec, I::AbstractVector{T}) =
-#  getindex0(x, PetscInt[ to_index(i)-1 for i in I ])
+getindex(x::Vec, i::Integer) = getindex0(x, PetscInt[i-1])[1]
 
 getindex(x::Vec, I::AbstractVector{PetscInt}) =
   getindex0(x, PetscInt[ (i-1) for i in I ])
 
-
 ##########################################################################
-import Base: abs, exp, log, conj, conj!, max, min, findmax, findmin, norm, maximum, minimum, .*, ./, +, -, scale!, dot, ==, !=, sum
-export normalize!, abs!, exp!, log!, chop!
 
+import Base: abs, exp, log, conj, conj!
+export abs!, exp!, log!
 for (f,pf) in ((:abs,:VecAbs), (:exp,:VecExp), (:log,:VecLog),
                (:conj,:VecConjugate))
     fb = symbol(string(f, "!"))
     @eval begin
         function $fb(x::Vec)
             chk(C.$pf(x.p))
-#            chk(ccall(($(Expr(:quote, pf)),petsc), PetscErrorCode,
- #                     (pVec,), x))
             x
         end
-
         $f(x::Vec) = $fb(copy(x))
     end
 end
 
 # skip for now
 #=
+export chop!
 function chop!(x::Vec, tol::Real)
     VecChop(x.c, tol)
     chk(ccall((:VecChop, petsc), PetscErrorCode, (pVec, PetscReal), x, tol))
@@ -292,38 +249,21 @@ function chop!(x::Vec, tol::Real)
 end
 =#
 
-
-# real versions
-for (f,pf, sf) in ((:findmax, :VecMax, :maximum), (:findmin, :VecMin, :minimum))
-#    ff = symbol(string("find", f))
+for (f, pf, sf) in ((:findmax, :VecMax, :maximum), (:findmin, :VecMin, :minimum))
     @eval begin
-        function $f{T <: Scalar}(x::Vec{T})
+        function Base.$f{T<:Real}(x::Vec{T})
             i = Array(PetscInt, 1)
             v = Array(T, 1)
             chk(C.$pf(x.p, i, v))
             (v[1], i[1]+1)
         end
-        $sf(x::Vec) = $f(x)[1]
+        Base.$sf{T<:Real}(x::Vec{T}) = $f(x)[1]
     end
 end
+# For complex numbers, VecMax and VecMin apparently return the max/min
+# real parts, which doesn't match Julia's maximum/minimum semantics.
 
-# complex versions
-for (f,pf) in ((:maximum, :VecMax), (:minimum, :VecMin))
-    ff = symbol(string("find", f))
-    @eval begin
-        function $ff{T}(x::Vec{Complex{T}})
-            i = Array(PetscInt, 1)
-            v = Array(T, 1)
-            chk(C.$pf(x.p, i, v))
-            (v[1], i[1]+1)
-        end
-        $f(x::Vec) = $ff(x)[1]
-    end
-end
-
-
-
-function norm{T <: Real}(x::Vec{T}, p::Number)
+function Base.norm{T<:Real}(x::Union{Vec{T},Vec{Complex{T}}}, p::Number)
     v = Array(T, 1)
     n = p == 1 ? C.NORM_1 : p == 2 ? C.NORM_2 : p == Inf ? C.NORM_INFINITY :
        throw(ArgumentError("unrecognized Petsc norm $p"))
@@ -331,42 +271,28 @@ function norm{T <: Real}(x::Vec{T}, p::Number)
     v[1]
 end
 
-function norm{T <: Real}(x::Vec{Complex{T}}, p::Number)
-    v = Array(PetscReal, 1)
-    n = p == 1 ? C.NORM_1 : p == 2 ? C.NORM_2 : p == Inf ? C.NORM_INFINITY :
-       throw(ArgumentError("unrecognized Petsc norm $p"))
-    chk(C.VecNorm(x.p, n, p))
-    v[1]
-end
-
-
-
-
 # computes v = norm(x,2), divides x by v, and returns v
-function normalize!{T <: Real}(x::Vec{T})
+function Base.normalize!{T<:Scalar}(x::Vec{T})
     v = Array(T, 1)
     chk(C.VecNormalize(x.p, v))
     v[1]
 end
 
-function normalize!{T <: Real}(x::Vec{Complex{T}})
-    v = Array(T, 1)
-    chk(C.VecNormalize(x.p, v))
-    v[1]
-end
-
-
-
-
-function dot{T}(x::Vec{T}, y::Vec{T})
+function Base.dot{T}(x::Vec{T}, y::Vec{T})
     d = Array(T, 1)
-    chk(C.VecDot(x.p, y.p, d))
-    d[1]
+    chk(C.VecDot(y.p, x.p, d))
+    return d[1]
 end
 
-# TODO: also add dotu for unconjugated dot product?  should go in Base first
+# unconjugated dot product (called for x'*y)
+function Base.At_mul_B{T<:Complex}(x::Vec{T}, y::Vec{T})
+    d = Array(T, 1)
+    chk(C.VecTDot(x.p, y.p, d))
+    return d
+end
 
 # pointwise operations on pairs of vectors (TODO: support in-place variants?)
+import Base: max, min, .*, ./
 for (f,pf) in ((:max,:VecPointwiseMax), (:min,:VecPointwiseMin),
                (:.*,:VecPointwiseMult), (:./,:VecPointwiseDivide))
     @eval function ($f)(x::Vec, y::Vec)
@@ -375,44 +301,46 @@ for (f,pf) in ((:max,:VecPointwiseMax), (:min,:VecPointwiseMin),
         w
     end
 end
+(.*)(x::Vec, a::Number...) = scale(x, prod(a))
+(.*)(a::Number, x::Vec) = scale(x, a)
+(./)(x::Vec, a::Number) = scale(x, inv(a))
+function (./)(a::Number, x::Vec)
+    y = copy(x)
+    chk(C.VecReciprocal(y.p))
+    if a != 1.0
+        scale!(y, a)
+    end
+    y
+end
 
-function scale!{T}(x::Vec{T}, s::Number)
+function Base.scale!{T}(x::Vec{T}, s::Number)
     chk(C.VecScale(x.p, T(s)))
     x
 end
 
-function (+){T <: Scalar}(x::Vec{T}, a::Number...)
-    C.VecShift(x.p, T(sum(a)))
-    x
+import Base: +, -, scale!
+function (+){T<:Scalar}(x::Vec{T}, a::Number...)
+    y = copy(x)
+    chk(C.VecShift(y.p, T(sum(a))))
+    return y
 end
-
-
-(+){T <: Scalar}(a::Number, x::Vec{T}) = x + a
-(-){T <: Scalar}(x::Vec{T}, a::Number) = x + (-a)
+(+){T<:Scalar}(a::Number, x::Vec{T}) = x + a
+(-){T<:Scalar}(x::Vec{T}, a::Number) = x + (-a)
 (-)(x::Vec) = scale(x, -1)
-(-){T <: Scalar}(a::Number, x::Vec{T}) = (-x) + a
-(.*){T <: Scalar}(x::Vec{T}, a::Number...) = scale(x, prod(a))
-(.*){T <: Scalar}(a::Number, x::Vec{T}) = scale(x, a)
-(./){T <: Scalar}(x::Vec{T}, a::Number) = scale(x, 1/a)
-
-
-function (./)(a::Number, x::Vec)
-
-    chk(C.VecReciprocal(x.p))
-    if a != 1.0
-        scale!(x, a)
-    end
-    x
+function (-){T<:Scalar}(a::Number, x::Vec{T})
+    y = -x
+    chk(C.VecShift(y.p, T(-a)))
+    return y
 end
 
+import Base: ==
 function (==)(x::Vec, y::Vec)
     b = Array(PetscBool,1)
     chk(C.VecEqual(x.p, y.b, b))
     b[1] != 0
 end
-(!=)(x::Vec, y::Vec) = !(x == y)
 
-function sum{T}(x::Vec{T})
+function Base.sum{T}(x::Vec{T})
     s = Array(T,1)
     chk(C.VecSum(x.p, s))
     s[1]
@@ -423,99 +351,58 @@ export axpy!, aypx!, axpby!, axpbypcz!
 import Base.LinAlg.BLAS.axpy!
 
 # y <- alpha*x + y
-function axpy!{T}(alpha::Number, x::Vec{T}, y::Vec)
+function axpy!{T}(alpha::Number, x::Vec{T}, y::Vec{T})
     chk(C.VecAXPY(y.p, T(alpha), x.p))
     y
 end
 # w <- alpha*x + y
-function axpy!{T}(alpha::Number, x::Vec{T}, y::Vec, w::Vec)
+function axpy!{T}(alpha::Number, x::Vec{T}, y::Vec{T}, w::Vec{T})
     chk(C.VecWAXPY(w.p, T(alpha), x.p, y.p))
     y
 end
 # y <- alpha*y + x
-function aypx!{T}(x::Vec{T}, alpha::Number, y::Vec)
+function aypx!{T}(x::Vec{T}, alpha::Number, y::Vec{T})
     chk(C.VecAYPX( y.p, T(alpha), x.p))
     y
 end
 # y <- alpha*x + beta*y
-function axpby!{T}(alpha::Number, x::Vec{T}, beta::Number, y::Vec)
+function axpby!{T}(alpha::Number, x::Vec{T}, beta::Number, y::Vec{T})
     chk(C.VecAXPBY(y.p, T(alpha), T(beta), x.p))
     y
 end
 # z <- alpha*x + beta*y + gamma*z
-function axpbypcz!{T}(alpha::Number, x::Vec{T}, beta::Number, y::Vec,
-                   gamma::Number, z::Vec)
+function axpbypcz!{T}(alpha::Number, x::Vec{T}, beta::Number, y::Vec{T},
+                      gamma::Number, z::Vec{T})
     chk(C.VecAXPBYPCZ(z.p, T(alpha), T(beta), T(gamma), x.p, y.p))
     z
 end
 
-#=
-# y <- \sum_i alphax[i][1]*alphax[i][2] + y
-function axpy!{T<:Number}(alphax::AbstractVector{(T,Vec)}, y::Vec)
-    n = length(alphax)
-    alpha = Array(T, n)
-    x = Array(Vec, n)
-    for i = 1:n
-        ax = alphax[i]
-        alpha[i] = ax[1]
-        x[i] = ax[2]
-    end
-
-    maxpy!(y, alpha, x)
-end
-=#
-function maxpy!{T <: Number, VType}(y::Vec, alpha::AbstractArray, x::Array{Vec{T, VType}})
-
-  @assert length(alpha) == length(x)
-  n = length(x)
-  _x = Array(C.Vec{T}, n)
-  _alpha = Array(T, n)
-  for i=1:n
-    _x[i] = x[i].p
-    _alpha[i] = alpha[i]
-  end
-
-  C.VecMAXPY(y.p, n, alpha, _x)
-  y
+# y <- y + \sum_i alpha[i] * x[i]
+function axpy!{V<:Vec}(y::V, alpha::AbstractArray, x::AbstractArray{V})
+    n = length(x)
+    length(alpha) == n || throw(BoundsError())
+    _x = [X.p for X in x]
+    _alpha = eltype(y)[a for a in alpha]
+    C.VecMAXPY(y.p, n, _alpha, _x)
+    y
 end
 
 ##########################################################################
-# elementwise operations
+# element-wise vector operations:
+import Base: .*, ./, .^, +, -
 
-function (.*)(x::Vec, y::Vec)
-  z = similar(x)
-#  println("before mult, z = ", z)
-  chk(C.VecPointwiseMult(z.p, x.p, y.p))
-  return z
+for (f,pf) in ((:.*,:VecPointwiseMult), (:./,:VecPointwiseDivide), (:.^,:VecPow))
+    @eval function ($f)(x::Vec, y::Vec)
+        z = similar(x)
+        chk(C.$pf(z.p, x.p, y.p))
+        return z
+    end
 end
 
-
-function (./)(x::Vec, y::Vec)
-  z = similar(x)
-  chk(C.VecPointwiseDivide(z.p, x.p, y.p))
-  return z
+for (f,s) in ((:+,1), (:-,-1))
+    @eval function ($f){T}(x::Vec{T}, y::Vec{T})
+        z = similar(x)
+        chk(C.VecWAXPY(z.p, T($s), y.p, x.p))
+        return z
+    end
 end
-
-
-
-function (.^){T}(x::Vec{T}, y::Number)
-  z = copy(x)
-  chk(C.VecPow(z.p, T(y)))
-  return z
-end
-
-function (+){T}(x::Vec{T}, y::Vec{T})
-  z = similar(x)
-  chk(C.VecWAXPY(z.p, T(1), x.p, y.p))
-  return z
-end
-
-function (-){T}(x::Vec{T}, y::Vec{T})
-  z = similar(x)
-  chk(C.VecWAXPY(z.p, T(-1), y.p, x.p))
-  return z
-end
-
-
-
-

--- a/test/mat.jl
+++ b/test/mat.jl
@@ -114,7 +114,7 @@ for i=1:3
   for j=1:3
     @fact mat6[i,j] => mat6j[i,j]
   end
-end 
+end
 
 vals_ret = mat6[idx, idy]
 @fact vals_ret => roughly(vals)
@@ -129,7 +129,7 @@ for i=1:3
   for j=1:3
     @fact mat7[i,j] => mat7j[i,j]
   end
-end 
+end
 
 vals_ret = mat7[1, idx]
 println("mat7 = ", mat7)
@@ -152,7 +152,7 @@ for i=1:3
   for j=1:3
     @fact mat8[i,j] => mat8j[i,j]
   end
-end 
+end
 
 vals_ret = mat8[idx, 1]
 @fact vals_ret => roughly(vals, atol= 1e-13)
@@ -168,7 +168,7 @@ for i=1:3
   for j=1:3
     @fact mat9[i,j] => mat9j[i,j]
   end
-end 
+end
 
 mat10 = PETSc.Mat(ST, 3, 3)
 mat10[idx, 1] = vt
@@ -179,7 +179,7 @@ for i=1:3
   for j=1:3
     @fact mat10[i,j] => mat10j[i,j]
   end
-end 
+end
 
 
 mat11 = PETSc.Mat(ST, 3, 3)
@@ -191,7 +191,7 @@ for i=1:3
   for j=1:3
     @fact mat11[i,j] => mat11j[i,j]
   end
-end 
+end
 
 
 
@@ -219,7 +219,7 @@ for i=1:3
   for j=1:3
     @fact mat13[i,j] => mat13j[i,j]
   end
-end 
+end
 
 
 # test conversion of values to a new type
@@ -234,7 +234,7 @@ for i=1:3
   for j=1:3
     @fact mat14[i,j] => mat14j[i,j]
   end
-end 
+end
 
 vt = RC(complex(1.,1))
 mat15 = PETSc.Mat(ST, 3,3)
@@ -245,7 +245,7 @@ for i=1:3
   for j=1:3
     @fact mat15[i,j] => roughly(vt)
   end
-end 
+end
 
 
 mat15jd = full(mat15)
@@ -253,7 +253,7 @@ for i=1:3
   for j=1:3
     @fact mat15[i,j] => roughly(mat15jd[i,j])
   end
-end 
+end
 
 # it appears get/set values don't work on a transposed matrix
 mat15_t = PETSc.MatTranspose(mat15)
@@ -264,7 +264,7 @@ for i=1:3
     println("mat15_t[j,i] = ", mat15_t[j, i])
     @fact mat15_t[j, i] => roughly(mat15[i,j])
   end
-end 
+end
 =#
 
 mat16 = PETSc.Mat(ST, 3, 3)
@@ -322,5 +322,20 @@ for i=1:3
   end
 end
 
+mat20= mat16+mat17
+mat20j = mat16j+mat17j
+for i=1:3
+  for j=1:3
+    @fact mat20[i,j] => roughly(mat20j[i,j])
+  end
+end
+
+mat21= mat16-mat17
+mat21j = mat16j-mat17j
+for i=1:3
+  for j=1:3
+    @fact mat21[i,j] => roughly(mat21j[i,j])
+  end
+end
 
 end

--- a/test/vec.jl
+++ b/test/vec.jl
@@ -9,7 +9,7 @@ len_ret = length(vec)
 
 @fact len_ret => 4
 size_ret = size(vec)
-@fact size_ret => (4,) 
+@fact size_ret => (4,)
 len_local = lengthlocal(vec)
 @fact len_local => 4
 size_local = sizelocal(vec)
@@ -120,8 +120,8 @@ println("vec4 = ", vec4)
 # reset vec4
 vec4_j = zeros(ST, length(vec4))
 for i=1:length(vec4)
-  vec4[i] = RC(complex(Float64(-i), Float64(-i))) 
-  vec4_j[i] = RC(complex(Float64(-i), Float64(-i))) 
+  vec4[i] = RC(complex(Float64(-i), Float64(-i)))
+  vec4_j[i] = RC(complex(Float64(-i), Float64(-i)))
 
 end
 
@@ -236,7 +236,7 @@ end
 
 println("testing 4 argument axpy")
 axpy!(vt, vec, vec2, vec4)
-vec4j = vt*vecj + vec2j 
+vec4j = vt*vecj + vec2j
 
 for i=1:length(vec)
   @fact vec2j[i] => vec2[i]
@@ -287,7 +287,7 @@ alphas = [vt2, vt3]
 println("vecs = ", vecs)
 println("typeof(vecs) = ", typeof(vecs))
 
-PETSc.maxpy!(vec4, alphas, vecs)
+axpy!(vec4, alphas, vecs)
 vec4j = vec4j + vt2*vecj + vt3*vec2j
 println("vec4 = ", vec4)
 println("vec4j = ", vec4j)
@@ -303,7 +303,7 @@ vec6j = zeros(ST, 3)
 
 for i=1:3
   i_float = Float64(i)
-  
+
   vec5[i] = RC(complex(i_float, i_float))
   vec6[i] = RC(complex(i_float+3, i_float+3))
   vec5j[i] = RC(complex(i_float, i_float))
@@ -348,11 +348,18 @@ for i=1:3
   @fact vec11[i] => roughly(vec11j[i])
 end
 
-
-
-
-
-
-
+# test unconjugated dot product
+let x = Vec(ST, 2), y = Vec(ST, 2)
+    copy!(y, [1, 1])
+    if ST <: Complex
+        copy!(x, [1, im])
+        @fact (x'*y)[1] => 1-im
+        @fact (x.'*y)[1] => 1+im
+    else
+        copy!(x, [2, 3])
+        @fact (x'*y)[1] => 5
+        @fact (x.'*y)[1] => 5
+    end
+end
 
 end


### PR DESCRIPTION
Sorry to lump a whole bunch of unrelated things into one PR, but I did a read-through of vec.jl and mat.jl and committed a bunch of small cleanups.

Some were minor things like deleting obsolete commented-out code, and making whitespace a bit more uniform.  But a few were more substantive, for example:

* It didn't make sense to have `MType` be *both* a type parameter and a member of `Mat`, so I removed the latter.  Also, since it is a type parameter, it doesn't make sense to change it, so I removed `settype!`.  Similarly for `Vec`.
* I made the constructors a bit more uniform, and added some missing `comm=` keywords.
* The `similar` functions were missing some methods, which I added.
* The `Vec + Scalar` functions forgot to make a copy of the vector, and so were modifying the argument.  I fixed this.
* The `Mat ± Mat` functions were buggy and untested; I fixed them.
* Indexing arrays with non-integer indices is now deprecated in Julia, so I dropped support for them here.
* Stylistically, I think it is clearer to define `Base.foo(...) = ...` than to do `import Base: foo`, or at least to put the `import` statement directly before the `foo` definition.  This way it is harder to accidentally forget an `import`, and it is clearer to read because it is more obvious which methods are overriding methods in `Base`
* I added a `Base.At_mul_B` method for the unconjugated dot product.
* I got rid of the `maxpy!` method in favor of just making it an `axpy!` variant.  My inclination would be to merge `axpbypcz!` in as well.
* `dot(x,y)` needs to call `VecDot(y,x)`, not `VecDot(x,y)`, because [VecDot conjugates the second argument rather than the first](http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Vec/VecDot.html).  Fixed and added a test.
* Uncommented the `Vec` finalizer (fixes #21).  Note that the `Mat` finalizer was already uncommented.