### PR TITLE
rename setsizes! to Base.resize!

### DIFF
--- a/src/mat.jl
+++ b/src/mat.jl
@@ -31,7 +31,7 @@ function Mat{T}(::Type{T}, m::Integer, n::Integer;
     mtype::Symbol=C.MATMPIAIJ)
 
     mat = Mat(T, mtype, comm=comm)
-    setsizes!(mat, m, n, mlocal=mlocal, nlocal=nlocal)
+    resize!(mat, m, n, mlocal=mlocal, nlocal=nlocal)
     setpreallocation!(mat, nz=nz, nnz=nnz, onz=onz, onnz=onnz)
     setoption!(mat, C.MAT_ROW_ORIENTED, false)  # julia data is column major
 
@@ -59,9 +59,14 @@ end
 
 gettype{T,MT}(a::Mat{T,MT}) = MT
 
-# fixme: should be method of Base.resize!
-function setsizes!(a::Mat, m::Integer, n::Integer;
+function Base.resize!(a::Mat, m::Integer=C.PETSC_DECIDE, n::Integer=C.PETSC_DECIDE;
                    mlocal::Integer=C.PETSC_DECIDE, nlocal::Integer=C.PETSC_DECIDE)
+    if m == mlocal == C.PETSC_DECIDE
+        throw(ArgumentError("either the global (m) or local (mlocal) #rows must be specified"))
+    end
+    if n == nlocal == C.PETSC_DECIDE
+        throw(ArgumentError("either the global (n) or local (nlocal) #cols must be specified"))
+    end
     chk(C.MatSetSizes(a.p, mlocal, nlocal, m, n))
     a
 end

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -25,7 +25,7 @@ end
 function Vec{T<:Scalar}(::Type{T}, len::Integer, vtype::C.VecType=C.VECSEQ;
                         comm=MPI.COMM_SELF, mlocal::Integer=C.PETSC_DECIDE)
   vec = Vec(T, vtype; comm=comm)
-  setsizes!(vec, mlocal, m=len)
+  resize!(vec, len, mlocal=mlocal)
   vec
 end
 
@@ -43,12 +43,14 @@ function petscview{T}(vec::Vec{T})
   chk(C.VecView(vec.p, viewer))
 end
 
-export gettype, setsizes!
+export gettype
 
 gettype{T,VT}(a::Vec{T,VT}) = VT
 
-# todo: this should be a method of Base.resize!
-function setsizes!(x::Vec, mlocal::Integer; m::Integer=C.PETSC_DECIDE)
+function Base.resize!(x::Vec, m::Integer=C.PETSC_DECIDE; mlocal::Integer=C.PETSC_DECIDE)
+    if m == mlocal == C.PETSC_DECIDE
+        throw(ArgumentError("either the length (m) or local length (mlocal) must be specified"))
+    end
     chk(C.VecSetSizes(x.p, mlocal, m))
     x
 end

--- a/test/vec.jl
+++ b/test/vec.jl
@@ -4,7 +4,7 @@ facts("\n --- Testing Vector Function ---") do
 vtype = PETSc.C.VECMPI
 vec = PETSc.Vec(ST, vtype)
 #PETSc.settype!(vec, vtype)
-PETSc.setsizes!(vec, 4)
+resize!(vec, 4)
 len_ret = length(vec)
 
 @fact len_ret => 4


### PR DESCRIPTION
`resize!` is the standard name for this functionality in Julia.   Also, the `Vec` and `Mat` `setsizes!` methods were inconsistent (the former put the global size first, then the local size as keywords, whereas the latter was the reverse); in both cases the `resize!` function is now Julian in that it takes the global sizes as the first (albeit optional) arguments, and the local sizes as keywords.