### PR TITLE
add Vec(::Vector) constructor

### DIFF
--- a/test/vec.jl
+++ b/test/vec.jl
@@ -362,4 +362,8 @@ let x = Vec(ST, 2), y = Vec(ST, 2)
     end
 end
 
+let x = rand(ST, 7)
+  @fact Vec(x) => x
+end
+
 end


### PR DESCRIPTION
Uses `VecCreateMPIWithArray` to create a no-copy PETSc wrapper around a Julia vector.