### PR TITLE
cleanup and expand IS functions

### DIFF
--- a/src/is.jl
+++ b/src/is.jl
@@ -1,24 +1,121 @@
 # index sets and vector scatters
-export IS, VecScatter, scatter!
+
+###########################################################################
+export IS # index sets
+# Note: we expose a 1-base Julian index interface, but internally
+# PETSc's indices are 0-based.
 
 type IS{T}
   p::C.IS{T}
-
-  # use default inner constructor
+  function IS(p::C.IS{T})
+    o = new(p)
+    finalizer(o, ISDestroy)
+    return o
+  end
 end
 
-function IS(T::DataType, idx::AbstractArray{PetscInt}; comm=MPI.COMM_SELF)
+function ISDestroy{T}(o::IS{T})
+  PetscFinalized(T) || C.ISDestroy(Ref(o.p))
+end
+
+# internal constructor, takes array of zero-based indices:
+function IS_(T::DataType, idx::Array{PetscInt}; comm=MPI.COMM_SELF)
   is_c = Ref{C.IS{T}}()
-#  println("is_c = ", is_c)
-#  println("typeof(is_c) = ", typeof(is_c))
   chk(C.ISCreateGeneral(comm, length(idx), idx, C.PETSC_COPY_VALUES, is_c))
   return IS{T}(is_c[])
 end
 
+IS{I<:Integer}(T::DataType, idx::AbstractArray{I}; comm=MPI.COMM_SELF) =
+  IS_(T, PetscInt[i-1 for i in idx]; comm=comm)
+
+function IS{I<:Integer}(T::DataType, idx::Range{I}; comm=MPI.COMM_SELF)
+  is_c = Ref{C.IS{T}}()
+  chk(C.ISCreateStride(comm, length(idx), start(idx)-1, step(idx), is_c))
+  return IS{T}(is_c[])
+end
+
+function Base.copy{T}(i::IS{T})
+  is_c = Ref{C.IS{T}}()
+  chk(C.ISDuplicate(i.p, is_c))
+  return IS{T}(is_c[])
+end
+
+function Base.length(i::IS)
+  len = Ref{PetscInt}()
+  chk(C.ISGetSize(i.p, len))
+  return Int(len[])
+end
+
+function lengthlocal(i::IS)
+  len = Ref{PetscInt}()
+  chk(C.ISGetLocalSize(i.p, len))
+  return Int(len[])
+end
+
+import Base.==
+function =={T}(i::IS{T}, j::IS{T})
+  b = Ref{PetscBool}()
+  chk(C.ISEqual(i.p, j.p, b))
+  return b[] != 0
+end
+
+function Base.sort!(i::IS)
+  chk(C.ISSort(i.p))
+  return i
+end
+Base.sort(i::IS) = sort!(copy(i))
+
+function Base.issorted(i::IS)
+  b = Ref{PetscBool}()
+  chk(C.ISSorted(i.p, b))
+  return b[] != 0
+end
+
+function Base.union{T}(i::IS{T}, j::IS{T})
+  is_c = Ref{C.IS{T}}()
+  chk(C.ISExpand(i.p, j.p, is_c))
+  return IS{T}(is_c[])
+end
+
+function Base.setdiff{T}(i::IS{T}, j::IS{T})
+  is_c = Ref{C.IS{T}}()
+  chk(C.ISDifference(i.p, j.p, is_c))
+  return IS{T}(is_c[])
+end
+
+function Base.extrema(i::IS)
+  min = Ref{PetscInt}()
+  max = Ref{PetscInt}()
+  chk(C.ISGetMinMax(i.p, min, max))
+  return (Int(min[])+1, Int(max[])+1)
+end
+Base.minimum(i::IS) = extrema(i)[1]
+Base.maximum(i::IS) = extrema(i)[2]
+
+function Base.convert{T<:Integer}(::Type{Vector{T}}, idx::IS)
+  pref = Ref{Ptr{PetscInt}}()
+  chk(C.ISGetIndices(idx.p, pref))
+  inds = Int[i+1 for i in pointer_to_array(pref[], lengthlocal(idx))]
+  chk(C.ISRestoreIndices(idx.p, pref))
+  return inds
+end
+Base.Set(i::IS) = Set(Vector{Int}(i))
+
+###########################################################################
+export VecScatter
+
+# describes a scatter operation context (input/output index sets etc.)
 type VecScatter{T}
   p::C.VecScatter{T}
+  function VecScatter(p::C.VecScatter{T})
+    o = new(p)
+    finalizer(o, VecScatterDestroy)
+    return o
+  end
+end
 
-  # use default innter constructor
+function VecScatterDestroy{T}(o::IS{T})
+  PetscFinalized(T) || C.VecScatterDestroy(Ref(o.p))
 end
 
 function VecScatter{T}(x::Vec{T}, ix::IS{T}, y::Vec{T}, iy::IS{T})
@@ -27,8 +124,26 @@ function VecScatter{T}(x::Vec{T}, ix::IS{T}, y::Vec{T}, iy::IS{T})
   return VecScatter{T}(scatter_c[])
 end
 
-function scatter!{T}(scatter::VecScatter{T}, x::Vec{T}, y::Vec{T}; imode=C.INSERT_VALUES, smode=C.SCATTER_FORWARD)
+function Base.copy{T}(i::VecScatter{T})
+  vs_c = Ref{C.VecScatter{T}}()
+  chk(C.VecScatterCopy(i.p, vs_c))
+  return VecScatter{T}(vs_c[])
+end
 
+###########################################################################
+export scatter!
+
+function scatter!{T}(scatter::VecScatter{T}, x::Vec{T}, y::Vec{T}; imode=C.INSERT_VALUES, smode=C.SCATTER_FORWARD)
   chk(C.VecScatterBegin(scatter.p, x.p, y.p, imode, smode))
+  yield() # do async computations while messages are in transit
   chk(C.VecScatterEnd(scatter.p, x.p, y.p, imode, smode))
+  return y
+end
+
+function scatter!{T,I1,I2}(x::Vec{T}, ix::AbstractVector{I1},
+                           y::Vec{T}, iy::AbstractVector{I2};
+                          imode=C.INSERT_VALUES, smode=C.SCATTER_FORWARD)
+  scatter = VecScatter(x, IS(T, ix, comm=x.comm),
+                       y, IS(T, iy, comm=y.comm))
+  scatter!(scatter, x, y; imode=imode, smode=smode)
 end

--- a/src/mat.jl
+++ b/src/mat.jl
@@ -38,13 +38,8 @@ function Mat{T}(::Type{T}, m::Integer, n::Integer;
     return mat
 end
 
-function MatDestroy(mat::Mat)
-  tmp = Array(PetscBool, 1)
-  C.PetscFinalized(eltype(mat), tmp)
-  if tmp[1] == 0  # if petsc has not been finalized yet
-    C.MatDestroy([mat.p])
-  end
-  # if Petsc has been finalized, let the OS deallocate the memory
+function MatDestroy{T}(mat::Mat{T})
+  PetscFinalized(T) || C.MatDestroy(Ref(mat.p))
 end
 
 function petscview{T}(mat::Mat{T})

--- a/src/petsc_com.jl
+++ b/src/petsc_com.jl
@@ -108,4 +108,8 @@ function petsc_sizeof(t::C.PetscDataType)
     s[1]
 end
 
-
+function PetscFinalized(T::Type)
+  tmp = Array(PetscBool, 1)
+  C.PetscFinalized(T, tmp)
+  return tmp[1] != 0
+end

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -41,13 +41,8 @@ function Vec{T<:Scalar}(v::Vector{T}; comm=MPI.COMM_SELF)
     return pv
 end
 
-function VecDestroy(vec::Vec)
-  tmp = Array(PetscBool, 1)
-  C.PetscFinalized(eltype(vec), tmp)
-  if tmp[1] == 0  # if petsc has not been finalized yet
-    C.VecDestroy([vec.p])
-  end
-   # if Petsc has been finalized, let the OS deallocate the memory
+function VecDestroy{T}(vec::Vec{T})
+  PetscFinalized(T) || C.VecDestroy(Ref(vec.p))
 end
 
 function petscview{T}(vec::Vec{T})

--- a/test/is.jl
+++ b/test/is.jl
@@ -1,0 +1,22 @@
+# Test index sets and vector gather/scatter
+
+facts("\n --- Testing IS Functions ---") do
+    let i = IS(ST, 10:-2:1), j = sort(i)
+        @fact issorted(i) --> false
+        @fact issorted(j) --> true
+        @fact i == j --> true
+        @fact i ∪ j == i --> true
+        @fact Vector{Int}(i) --> [10:-2:1;]
+        @fact Vector{Int}(j) --> [2:2:10;]
+        @fact length(i) --> 5
+        @fact lengthlocal(i) --> 5
+        @fact minimum(i) --> 2
+        @fact maximum(i) --> 10
+        @fact Set(setdiff(i, IS(ST, 1:4))) --> Set(6:2:10)
+        @fact Set(union(i, IS(ST, [1,2,3,4]))) --> Set(2:2:10) ∪ Set(1:4)
+    end
+
+    let x = Vec(ST[1,17,24,2]), y = Vec(ST, 2)
+        @fact scatter!(x, 2:3, y, 1:2) --> [17,24]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,7 @@ for ST in [Float64, Float32, Complex128]
   include("vec.jl")
   include("mat.jl")
   include("ksp.jl")
+  include("is.jl")
 end
 
 


### PR DESCRIPTION
This is some cleanup of the functions in `is.jl`, including:

* Adding finalizers
* Adding tests
* More constructors
* length, union, setdiff, extrema, minimum/maximum, and conversion to `Vector{Int}` and `Set{Int}`
* expose a Julian 1-based index interface (automatically converting internally to/from 0-based indices)
* a `scatter!` function that lets you pass the index vectors directly and constructs the `IS` and `VecScatter` objects for you.