### PR TITLE
remove .comm fields in favor of a comm(x) method that calls PetscObjectComm

### DIFF
--- a/src/generated/defs.jl
+++ b/src/generated/defs.jl
@@ -49,3 +49,14 @@ function symbol_set_before(sym_arr)
   end
 
 end
+
+# TODO: auto-generate these
+function PetscObjectComm(::Type{Float64},arg1::Ptr)
+   ccall((:PetscObjectComm,petscRealDouble),comm_type,(Ptr{Void},),arg1)
+end
+function PetscObjectComm(::Type{Float32},arg1::Ptr)
+   ccall((:PetscObjectComm,petscRealSingle),comm_type,(Ptr{Void},),arg1)
+end
+function PetscObjectComm(::Type{Complex128},arg1::Ptr)
+   ccall((:PetscObjectComm,petscComplexDouble),comm_type,(Ptr{Void},),arg1)
+end

--- a/src/is.jl
+++ b/src/is.jl
@@ -14,6 +14,8 @@ type IS{T}
   end
 end
 
+comm{T}(a::IS{T}) = MPI.Comm(C.PetscObjectComm(T, a.p.pobj))
+
 function ISDestroy{T}(o::IS{T})
   PetscFinalized(T) || C.ISDestroy(Ref(o.p))
 end
@@ -114,6 +116,8 @@ type VecScatter{T}
   end
 end
 
+comm{T}(a::VecScatter{T}) = MPI.Comm(C.PetscObjectComm(T, a.p.pobj))
+
 function VecScatterDestroy{T}(o::IS{T})
   PetscFinalized(T) || C.VecScatterDestroy(Ref(o.p))
 end
@@ -143,7 +147,7 @@ end
 function scatter!{T,I1,I2}(x::Vec{T}, ix::AbstractVector{I1},
                            y::Vec{T}, iy::AbstractVector{I2};
                           imode=C.INSERT_VALUES, smode=C.SCATTER_FORWARD)
-  scatter = VecScatter(x, IS(T, ix, comm=x.comm),
-                       y, IS(T, iy, comm=y.comm))
+  scatter = VecScatter(x, IS(T, ix, comm=comm(x)),
+                       y, IS(T, iy, comm=comm(y)))
   scatter!(scatter, x, y; imode=imode, smode=smode)
 end

--- a/src/ksp.jl
+++ b/src/ksp.jl
@@ -11,16 +11,18 @@ type KSP{T, MType}
   A::Mat{T, MType}
 end
 
+comm{T}(a::KSP{T}) = comm(A)
+
 function KSP{T, MType}(A::Mat{T, MType}, pc_mat::Mat{T, MType}=A)
   ksp_arr = Array(C.KSP{T}, 1)
   pc_arr = Array(C.PC{T}, 1)
 
-  chk(C.KSPCreate(A.comm, ksp_arr))
+  chk(C.KSPCreate(comm(A), ksp_arr))
   ksp = ksp_arr[1]
   C.KSPGetPC(ksp, pc_arr)
   pc = pc_arr[1]
 
-  rank = MPI.Comm_rank(A.comm)
+  rank = MPI.Comm_rank(comm(A))
   chk(C.KSPSetOperators(ksp, A.p, pc_mat.p))
  # call KSPSetOptions from here
 


### PR DESCRIPTION
The principle being that we should never store anything twice.  (Not to save space, but rather to avoid the risk that the two copies get out of sync.)