### PR TITLE
use 2-space indentation uniformly

### DIFF
--- a/src/PETSc.jl
+++ b/src/PETSc.jl
@@ -1,11 +1,6 @@
 module PETSc
 
 import MPI
-import Base.*
-import Base.(.^)
-#generated_path = joinpath(Pkg.dir("PETSc"), "src/auto2/generated")
-#push!(LOAD_PATH, generated_path)
-
 include(joinpath("generated", "C.jl"))
 using .C
 include("petsc_com.jl")
@@ -14,12 +9,5 @@ include("mat.jl")
 include("error.jl")
 include("ksp.jl")
 include("is.jl")
-
-#=
-function __init__()
-
-    PetscInitialize()
-end
-=#
 
 end

--- a/src/error.jl
+++ b/src/error.jl
@@ -4,31 +4,29 @@
 
 # wrap this around all PETSc ccalls, in order to catch exceptions
 function chk(errnum)
-    if errnum != 0
-         println(STDERR, "Error number $errnum has occured")
-         throw(PetscError(errnum))
-    end
-    nothing
+  if errnum != 0
+    println(STDERR, "Error number $errnum has occured")
+    throw(PetscError(errnum))
+  end
+  nothing
 end
 
 immutable PetscError <: Exception
-    errnum::PetscErrorCode
-    msg::AbstractString
-    PetscError(n::Integer, m="") = new(convert(PetscErrorCode, n),
-                                       PetscErrorMessage(n))
+  errnum::PetscErrorCode
+  msg::AbstractString
+  PetscError(n::Integer, m="") = new(convert(PetscErrorCode, n),
+  PetscErrorMessage(n))
 end
 
 # return error message string corresponding to errnum
 function PetscErrorMessage(errnum)
-#    println("entered PetscErrorMessage")
-    arr = Array(Ptr{UInt8}, 1)
-    arr_ptr = pointer(arr)
-    # use the first petsc library for all cases
-    C.PetscErrorMessage(C.petsc_type[1], errnum,  arr_ptr, Ref{Ptr{UInt8}}(0))
-#    println("retrieved error message from petsc")
-    str = bytestring(arr[1])
-#    println("error message = ", str)
-#    msg[1] ==  ? "(unknown)" : bytestring(msg[1])
+  #    println("entered PetscErrorMessage")
+  arr = Array(Ptr{UInt8}, 1)
+  arr_ptr = pointer(arr)
+  # use the first petsc library for all cases
+  C.PetscErrorMessage(C.petsc_type[1], errnum,  arr_ptr, Ref{Ptr{UInt8}}(0))
+  #    println("retrieved error message from petsc")
+  str = bytestring(arr[1])
+  #    println("error message = ", str)
+  #    msg[1] ==  ? "(unknown)" : bytestring(msg[1])
 end
-
-

--- a/src/generated/C.jl
+++ b/src/generated/C.jl
@@ -1,8 +1,6 @@
 module C
 
 using Compat
-
-
 export PetscInt
 
 include("defs.jl")
@@ -11,4 +9,5 @@ include("PETScRealDouble.jl")
 include("PETScRealSingle.jl")
 include("PETScComplexDouble.jl")
 include("defs2.jl")
+
 end

--- a/src/generated/defs2.jl
+++ b/src/generated/defs2.jl
@@ -1,11 +1,8 @@
 # hacky definitions that Clang did not pick up
 typealias PetscCopyMode Int32
-PETSC_COPY_VALUES = Int32(0)
+const PETSC_COPY_VALUES = Int32(0)
 
 function ISCreateGeneral(arg1::MPI_Comm,arg2::Integer,arg3::Union{Ptr{Int64},StridedArray{Int64},Ptr{Int64},Ref{Int64}}, arg3a::Integer,arg4::Union{Ptr{IS{Float64}},StridedArray{IS{Float64}},Ptr{IS{Float64}},Ref{IS{Float64}}})
-    err = ccall((:ISCreateGeneral,petscRealDouble),PetscErrorCode,(comm_type,Int64,Ptr{Int64},Cint,Ptr{IS{Float64}}),arg1,arg2,arg3,arg3a,arg4)
-    return err
+  err = ccall((:ISCreateGeneral,petscRealDouble),PetscErrorCode,(comm_type,Int64,Ptr{Int64},Cint,Ptr{IS{Float64}}),arg1,arg2,arg3,arg3a,arg4)
+  return err
 end
-
-
-

--- a/src/generated/rewriter.jl
+++ b/src/generated/rewriter.jl
@@ -10,9 +10,9 @@ using DataStructures
 
 # used to modify function signatures
 type_dict = Dict{Any, Any} (
-:PetscScalar => :Float64,
-:PetscReal => :Float64,
-:PetscInt => :Int64,
+  :PetscScalar => :Float64,
+  :PetscReal => :Float64,
+  :PetscInt => :Int64,
 )
 
 const petsc_libname = :petscRealDouble
@@ -22,45 +22,36 @@ type_dict_single = Dict{Any, Any} (
 :(Ptr{UInt8}) => Union{ByteString, Symbol, Array{UInt8}}
 )
 
-
-
 # used to convert typealiases to immutable type definionts
 # currently, if the key exists, it is converted
 # if value == 1, create new immutable type
 # otherwise replace key with value
 # also used for function signatures
 new_type_dict = Dict{Any, Any} (
-:Vec => :(Vec{$val_tmp}),
-:Mat => :(Mat{$val_tmp}),
-:KSP => :(KSP{$val_tmp}),
-:PC => :(PC{$val_tmp}),
-:PetscViewer => :(PetscViewer{$val_tmp}),
-:PetscOption => :(PetscOption{$val_tmp}),
-:IS => :(IS{$val_tmp}),
-:ISLocalToGlobalMapping => :(ISLocalToGlobalMapping{$val_tmp}),
-:ISColoring => :(ISColoring{$val_tmp}),
-:PetscLayout => :(PetscLayout{$val_tmp}),
-:VecScatter => :(VecScatter{$val_tmp}),
+  :Vec => :(Vec{$val_tmp}),
+  :Mat => :(Mat{$val_tmp}),
+  :KSP => :(KSP{$val_tmp}),
+  :PC => :(PC{$val_tmp}),
+  :PetscViewer => :(PetscViewer{$val_tmp}),
+  :PetscOption => :(PetscOption{$val_tmp}),
+  :IS => :(IS{$val_tmp}),
+  :ISLocalToGlobalMapping => :(ISLocalToGlobalMapping{$val_tmp}),
+  :ISColoring => :(ISColoring{$val_tmp}),
+  :PetscLayout => :(PetscLayout{$val_tmp}),
+  :VecScatter => :(VecScatter{$val_tmp}),
 )
-
 
 # definitions that will be provided, but don't come from Petsc
 # mostly MPI stuff
 const_defs = Dict{Any, Any} (
-:MPI_COMM_SELF => 1,
-:MPI_Comm => 1,
-:comm_type => 1,
+  :MPI_COMM_SELF => 1,
+  :MPI_Comm => 1,
+  :comm_type => 1,
 )
-
 
 # dictionary to hold names of types
 # that are aliased to Symbol
-symbol_type_dict = Dict{Any, Any} (
-
-)
-
-
-
+symbol_type_dict = Dict{Any, Any} ()
 
 # create a string array mirroring a symbol array
 function send_symbol(x::AbstractArray)
@@ -70,26 +61,18 @@ function send_symbol(x::AbstractArray)
       string_arr[i] = copy(x[i])
     end
   end
-
   return string_arr
 end
 
 # get a string array and turn it into a symbol array
 function return_symbol(string_array::AbstractArray, x::AbstractArray)
-
   for i=1:length(x)
     x[i] = bytestring(string_array[i])
   end
 end
 
-
-
-
-
-
 # things to be recursively replaced in function signatures
-sig_rec_dict = Dict{Any, Any} (
-)
+sig_rec_dict = Dict{Any, Any} ()
 
 for i in keys(type_dict)
   get!(sig_rec_dict, i, type_dict[i])
@@ -102,18 +85,17 @@ end
 # things to be replaced in function signatures only if they
 # are top level (ie. this does a non recursive replace)
 sig_single_dict = Dict{Any, Any} (
-:(Ptr{UInt8}) => :(Union{ByteString, Symbol, Array{UInt8}}),
-:Int32 => :Integer,
-:Int64 => :Integer,
-:Cint => :Integer,
-:PetscInt => :Integer,
+  :(Ptr{UInt8}) => :(Union{ByteString, Symbol, Array{UInt8}}),
+  :Int32 => :Integer,
+  :Int64 => :Integer,
+  :Cint => :Integer,
+  :PetscInt => :Integer,
 )
-
 
 # list of symbols to search for
 # if none are found, then a dummy argument is added
 sig_dummyarg_dict = Dict{Any, Any}(
-:PetscScalar => 1,
+  :PetscScalar => 1,
 )
 
 # add keys from new_type_dict because dummy arg check
@@ -138,15 +120,11 @@ end
 # things to be replace in the ccall argument list only if
 # they are top level (ie. this does a non recursive replace)
 ccall_single_dict = Dict{Any, Any} (
-:(Ptr{UInt8}) => :Cstring,
+  :(Ptr{UInt8}) => :Cstring,
 )
-
-
 
 # things to be replaced recurisvely in typealias rhs
-typealias_rec_dict = Dict{Any, Any} (
-
-)
+typealias_rec_dict = Dict{Any, Any} ()
 
 for i in keys(type_dict)
   get!(typealias_rec_dict, i, type_dict[i])
@@ -157,9 +135,7 @@ for i in keys(new_type_dict)
 end
 
 # dictionary of typealiases to exclude based on the lhs argument
-typealias_lhs_dict = Dict{Any, Any} (
-
-)
+typealias_lhs_dict = Dict{Any, Any} ()
 
 for i in keys(type_dict)
   get!(typealias_lhs_dict, i, i)
@@ -176,13 +152,11 @@ typealias_single_dict = Dict{Any, Any} (
 # key = typealias rhs values to exclude
 # if values == 1, then create an immutable type
 typealias_exclude_dict = Dict{Any, Any} (
-
 )
 
 for i in keys(new_type_dict)
   get!(typealias_exclude_dict, i, 1)
 end
-
 
 # things to be recurisvely replace in constant declaration rhs
 const_rec_dict = Dict{Any, Any} (
@@ -197,99 +171,23 @@ for i in keys(new_type_dict)
   get!(const_rec_dict, i, new_type_dict[i])
 end
 
-println("const_rec_dict = ", const_rec_dict)
-
-#=
-# dictionary for rewriting pointer type annotations in function signatures
-# Ptrs are converted to Union(Ptr{ptype}, StridedArray{ptype}, Ptr{Void})
-# the objects in the typealias_dict are added automatically
-# the keys can be either symbols or expressions
-# if the entire type annotation matches a key, it is replace
-# if any symbol in the type annotation matches a key, it is replaced
-ptr_dict = Dict{Any, Any} (
-#:(Ptr{PetscInt}) => :(Union(Ptr{PetscInt}, StridedArray{PetscInt}, Ptr{Void}))
-#:Mat => :Mat{S <: type_dict[:PetscScalar]}
-)
-
-for i in keys(typealias_dict)
-  if typealias_dict[i] == 1  # only do immutable type definitions
-    get!(ptr_dict, i, :($i{PetscScalar}))
-  end
-end
-
-println("ptr_dict = ", ptr_dict)
-
-#=
-# used to replace symbols on the right hand side of constant definitions
-# the type_dict is automatically includes
-const_dict = Dict{Any, Any} (
-:NULL => :C_NULL,
-)
-
-
-for i in keys(type_dict)
-  get!(const_dict, i, type_dict[i])
-end
-=#
-
-# used to modify ccall arguments
-# the contents of type_dict are automatically included
-# the type paramaterizations are from the tyepalias_dict
-# are also automatically included
-ccall_dict = OrderedDict{Any, Any} (
-#:Mat => :(Ptr{Void}),
-#:MPI_Comm => :comm_type,  # need to change ccall arg name to argname.val
-#:(Ptr{UInt8}) => :Cstring,
-#:(Ptr{Cstring}) => Ptr{Ptr{UInt8}},  #
-)
-
-ccall_dict[:MPI_Comm] = :comm_type
-
-ccall_dict[:(Ptr{Cstring})] = :(Ptr{Ptr{UInt8}})
-ccall_dict[:(Ptr{UInt8})] = :Cstring
-
-for i in keys(type_dict)
-  get!(ccall_dict, i, type_dict[i])
-end
-
-for i in keys(typealias_dict)
-  val = type_dict[:PetscScalar]
-  if typealias_dict[i] == 1
-    get!(ccall_dict, i, :($i{$val}))
-  end
-end
-
-=#
-
-
-
-
-
-
-
 function petsc_rewriter(obuf)
-
   for i=1:length(obuf)
-    println("i = ", i)
     ex_i = obuf[i]  # obuf is an array of expressions
-
-    println("ex_i = ", ex_i)
-    println("typeof(ex_i) = ", typeof(ex_i))
 
     if typeof(ex_i) == Expr
       head_i = ex_i.head  # function
       # each ex_i has 2 args, a function signature and a function body
-      println("head_i = ", head_i)
 
       # figure out what kind of expression it is, do the right modification
       if head_i == :function  # function declaration
-       obuf[i] = process_func(ex_i)
+        obuf[i] = process_func(ex_i)
       elseif ex_i.head == :const  # constant declaration
         obuf[i] = process_const(ex_i)
       elseif ex_i.head == :typealias  # typealias definition
         obuf[i] = fix_typealias(ex_i)
-     elseif ex_i.head == :type
-       obuf[i] = process_type(ex_i)
+      elseif ex_i.head == :type
+        obuf[i] = process_type(ex_i)
 
       else  # some other kind of expression
         println("not processing expression", ex_i)
@@ -320,8 +218,6 @@ function petsc_rewriter(obuf)
     else
       println("not processing ", typeof(ex_i))
     end  # end if Expr
-
-
   end
 
   return obuf  # return modified obuf
@@ -330,14 +226,12 @@ end
 
 ##### functions to rewrite function signature #####
 function process_func(ex)
-
   @assert ex.head == :function  # this is a function declaration
 
   ex.args[1] = rewrite_sig(ex.args[1])  # function signature
   ex.args[2] = rewrite_body(ex.args[2])  # function body
 
   # now check if any undefined type annotations remain
-
   sum = 0
   ex_sig = ex.args[1]
   ex_body = ex.args[2]
@@ -357,12 +251,8 @@ function process_func(ex)
     return "#= skipping function with undefined symbols: \n $ex \n=#"
   end
 
-
   # now add any extra expression needed
   ex = add_body(ex)
-
-
-
   return ex
 end
 
@@ -469,7 +359,7 @@ end
 
 
 function get_ccall_index(ex)
-# returns the index of the first ccall in the arguments of ex
+  # returns the index of the first ccall in the arguments of ex
 
   index = 0
 
@@ -496,18 +386,18 @@ function rewrite_sig(ex)  # rewrite the function signature
 
   # ex.args[1] = function name, as a symbol
 
-   # check if function contains a PetscScalar
+  # check if function contains a PetscScalar
 
-   # if yes, add paramterization, do search and replace PetscScalar -> S
-   # also add macro
+  # if yes, add paramterization, do search and replace PetscScalar -> S
+  # also add macro
 
-   println("rewrite_sig ex = ", ex)
+  println("rewrite_sig ex = ", ex)
 
   # Process all arguments of the function
   # Replace all pointers with Unions(Ptr, AbstractArray...)
   # do any other transformations in ptr_dict
   for i=2:length(ex.args)
-   # each of ex.args is an expression containing arg name, argtype
+    # each of ex.args is an expression containing arg name, argtype
     println("typeof(ex.args[$i]) = ", typeof(ex.args[i]))
     @assert typeof(ex.args[i]) == Expr  || typeof(ex.args[i]) == Symbol  # verify these are all expressions
     ex.args[i] = process_sig_arg(ex.args[i])  # process each expression
@@ -515,17 +405,17 @@ function rewrite_sig(ex)  # rewrite the function signature
 
 
 
-   # check for any symbol that will uniquely identify which
-   # version of petsc to call
-   println("checking for uniqueness of signature")
-   println("ex = ", ex)
+  # check for any symbol that will uniquely identify which
+  # version of petsc to call
+  println("checking for uniqueness of signature")
+  println("ex = ", ex)
 
-   val = contains_symbol(ex, :PetscScalar)
-   for i in keys(sig_dummyarg_dict)
-       val += contains_symbol(ex, i)
-   end
+  val = contains_symbol(ex, :PetscScalar)
+  for i in keys(sig_dummyarg_dict)
+    val += contains_symbol(ex, i)
+  end
 
-   println("contains_symbol = ", val)
+  println("contains_symbol = ", val)
 
   if val == 0  # if no arguments will make the function signature unique
 
@@ -533,136 +423,53 @@ function rewrite_sig(ex)  # rewrite the function signature
     ex = add_dummy_arg(ex)
   end
 
-#=
+  #=
   println("replacing typealiases")
   println("ex = ", ex)
   # do second pass to replace Petsc typealiases with a specific type
   for i=2:length(ex.args)
-    for j in keys(type_dict)  # check for all types
+  for j in keys(type_dict)  # check for all types
 
-    println("replacing ", j, ", with ", type_dict[j])
-      ex.args[i] = replace_symbol(ex.args[i], j, type_dict[j])
-    end
-  end
+  println("replacing ", j, ", with ", type_dict[j])
+  ex.args[i] = replace_symbol(ex.args[i], j, type_dict[j])
+end
+end
 
-  println("after modification rewrite_sig ex = ", ex)
+println("after modification rewrite_sig ex = ", ex)
 =#
-  return ex
+return ex
 end
 
 function process_sig_arg(ex)
-# take the expression that is an argument to the function and rewrite it
+  # take the expression that is an argument to the function and rewrite it
 
-   @assert ex.head == :(::)
+  @assert ex.head == :(::)
 
-   # modify args here
-#   arg_name = ex.args[1]  # symbol
-#   arg_type = ex.args[2]  # Expr contianing type tag
-   println("ex.args[2] = ", ex.args[2])
-   println("type = ", typeof(ex.args[2]))
+  # modify args here
+  #   arg_name = ex.args[1]  # symbol
+  #   arg_type = ex.args[2]  # Expr contianing type tag
+  println("ex.args[2] = ", ex.args[2])
+  println("type = ", typeof(ex.args[2]))
 
-#   if typeof(ex.args[1]) == Symbol
+  #   if typeof(ex.args[1]) == Symbol
 
-   # get only typetag expression, modify it
-   ex.args[2] = modify_typetag(ex.args[2])
+  # get only typetag expression, modify it
+  ex.args[2] = modify_typetag(ex.args[2])
 
-   return ex
+  return ex
 end
 
 function modify_typetag(ex)
-
-  println("\nentered modify_typetag")
-  # transform entire expressions
-  println("transforming entire expression")
-  println("before expression = ", ex)
-
-
   # do non recursive replace first
   ex = get(sig_single_dict, ex, ex)
 
-
   # now do recursive search and replace
-
   for i in keys(sig_rec_dict)
     ex = replace_symbol(ex, i, sig_rec_dict[i])
   end
 
-#=
-  if typeof(ex) == Expr
-    if haskey(ptr_dict, ex)
-     println("transforming ", ex, " to ", ptr_dict[ex])
-
-     ex = get(ptr_dict, ex, ex)
-    end
-  end
-=#
-  println("after expression = ", ex)
-#=
-  # transform individual symbols only
-  if typeof(ex) == Symbol
-    println("transforming symbols only")
-    ex = get(sym_dict, ex, ex)
-  end
-=#
-#=
-  if typeof(ex) == Expr
-    println("after, ex.head = ", ex.head)
-    println("ex.args = ", ex.args)
-    println("ex = ", ex)
-  else
-    println("typeof(ex) = ", typeof(ex))
-  end
-=#
-
-#=
-  # replace individual symbols
-  println("\nreplacing symbols")
-  cnt = 0
-  for i in keys(ptr_dict)
-    println("replacing symbols ", cnt)
-    println("replacingabc ", i, " in expression ", ex, " with ", ptr_dict[i])
-    ex = replace_symbol(ex, i, ptr_dict[i])
-    println("after replacingabc, typeof(ex) = ", typeof(ex))
-    println("ex = ", ex)
-#=
-    if typeof(ex) == Expr
-      println("ex.head = ", ex.head)
-      for i=1:length(ex.args)
-        println("  typeof(ex.args[$i]) = ", typeof(ex.args[i]))
-      end
-
-      for i=1:length(ex.args)
-        if typeof(ex.args[i]) == Expr
-          println("  ex.args[$i].head = ", ex.args[i].head)
-          for j=1:length(ex.args[i].args)
-            println("  typeof(ex.args[$i].args[$j] = ", typeof(ex.args[i].args[j]))
-            if typeof(ex.args[i].args[j]) == Expr
-              println("    ex.args[$i].args[$j].head = ", ex.args[i].args[j].head)
-              for k=1:length(ex.args[i].args[j].args)
-                if typeof(ex.args[i].args[j].args[k]) == Expr
-                  println("      ex.args[$i].args[$j].args[$k].head = ", ex.args[i].args[j].args[k].head)
-#                  println("      ex.args[$i].args[$j].args[$k] = ", ex.args[i].args[j].args[k])
-                 end
-               end
-
-            end
-          end
-        end
-      end
-#      println("number of symbols = ", count_depth(0, ex))
-      println("ex.args = ", ex.args)
-    end
-=#
-    cnt += 1
-    print("\n")
-
-  end
-=#
-  println("after recursively replacing symbols, ex = ", ex)
-
-  println("replacing pointer with Union")
   # should make sure there are no nested pointers?
-#  @assert ex.head == :curly || ex.head == :symbol # verify this is a typetag
+  #  @assert ex.head == :curly || ex.head == :symbol # verify this is a typetag
   if typeof(ex) == Expr
     # replace pointer with Union of ptr, array, c_null
     if ex.head == :curly && ex.args[1] == :Ptr
@@ -671,14 +478,11 @@ function modify_typetag(ex)
     end
   end
 
-  println("after replacing union, ex = ", ex)
-
   return ex
 end
 
 function add_param(ex)
-# add the {S <: PetscScalar} to a function declaration
-
+  # add the {S <: PetscScalar} to a function declaration
   @assert typeof(ex) == Symbol  # make sure we don't already have a paramaterization
 
   # could do more extensive operations here
@@ -686,8 +490,8 @@ function add_param(ex)
 end
 
 function add_dummy_arg(ex)
-# add a dummy argument to the function argument list
-# ex is the function name + args (ie. the entire function signature)
+  # add a dummy argument to the function argument list
+  # ex is the function name + args (ie. the entire function signature)
 
   println("adding dummy argument to ", ex)
   @assert ex.head == :call
@@ -721,20 +525,15 @@ end
 
 #####  function to  rewrite the body of the function #####
 function rewrite_body(ex)  # rewrite body of a function
-
-
   @assert ex.head == :block
   # ex has only one argument, the ccall
   # could insert other statements arond the ccall here?
-
   ex.args[1] = process_ccall(ex.args[1])
-
   return ex
 end
 
 
 function process_ccall(ex)
-
   @assert ex.head == :ccall  # verify this is the ccall statement
   # args[1] = Expr, tuple of fname, libname
   # args[2] = return type, symbol
@@ -746,25 +545,15 @@ function process_ccall(ex)
   ex.args[3] = modify_types(ex.args[3])
   println("changing argument names")
   ex3 = ex.args[3]  # get expression of argument types
-#  ex4 = ex.args[4]  # get expression argument names
+  #  ex4 = ex.args[4]  # get expression argument names
 
   @assert ex3.head == :tuple
 
   return ex
-
 end
 
 function modify_types(ex)
-
   @assert ex.head == :tuple
-
-#=
-  for i=1:length(ex.args)
-    for j in keys(ccall_dict)
-      ex.args[i] = replace_symbol(ex.args[i], j, ccall_dict[j])
-i#      ex.args[i] = get(ccall_dict, ex.args[i], ex.args[i])  # get the new argument type symbol from dictionary
-  end                                                      # use existing type of no key found
-=#
 
   # do non recursive replace first
   for i=1:length(ex.args)
@@ -781,32 +570,19 @@ i#      ex.args[i] = get(ccall_dict, ex.args[i], ex.args[i])  # get the new argu
     end
   end
 
-#=
-  new_ex = deepcopy(ex)
-  for i in reverse(collect(keys(ccall_dict)))
-    println("looking to replace ", i, " with ", ccall_dict[i], " in expression ", new_ex)
-    new_ex = replace_symbol(new_ex, i, ccall_dict[i])
-  end
-=#
   return deepcopy(ex)
 end
 
 function modify_libname(ex)
-
   @assert ex.head == :tuple
-
   ex.args[2] = petsc_libname  # replace libname with a new one
-
   return ex
 end
 
 ##### functions to make consts into global consts #####
 
 function process_const(ex)
-
   @assert ex.head == :const
-
-
 
   # do any replacements
   for j in keys(const_rec_dict)
@@ -814,13 +590,10 @@ function process_const(ex)
   end
 
   ex2 = ex.args[1]  # get the assignment
-#  ex.args[1] = :(global $val)  # make it global
-
 
   rhs = ex2.args[2]
   tmp = are_syms_defined(rhs)
   if tmp != 0  # something is undefined
-#    println("returning comment message")
     lhs = ex2.args[1]
     delete!(wc.common_buf, lhs)  # remove lh from list of defined symbols
     return "#skipping undefined $ex"  # replace expression with constant
@@ -832,122 +605,76 @@ function process_const(ex)
   end
 
   return deepcopy(ex)
-
 end
 
 
 function fix_typealias(ex)
-
   @assert ex.head == :typealias
   new_type = ex.args[1]
 
-    if haskey(typealias_exclude_dict, new_type)
-      if typealias_exclude_dict[new_type] == 1
-        # construct immutable type definition
-        fields = Expr(:(::), :pobj, :(Ptr{Void}))
-        body = Expr(:block, fields)
-        typename = Expr(:curly, new_type, :T)  # add static parameter T
-        ex_new = Expr(:type, false, typename, body)
-        return ex_new
-      else
-        if haskey(wc.common_buf, new_type)
-          delete!(wc.common_buf, new_type)  # record that symbol is now undefined
-        end
-        return "# excluding $ex"
-       end
+  if haskey(typealias_exclude_dict, new_type)
+    if typealias_exclude_dict[new_type] == 1
+      # construct immutable type definition
+      fields = Expr(:(::), :pobj, :(Ptr{Void}))
+      body = Expr(:block, fields)
+      typename = Expr(:curly, new_type, :T)  # add static parameter T
+      ex_new = Expr(:type, false, typename, body)
+      return ex_new
+    else
+      if haskey(wc.common_buf, new_type)
+        delete!(wc.common_buf, new_type)  # record that symbol is now undefined
+      end
+      return "# excluding $ex"
     end
+  end
 
-    # if we didn't create immutable type, transform the rhs according to the
-    # dictionaries
+  # if we didn't create immutable type, transform the rhs according to the
+  # dictionaries
+  lhs = deepcopy(ex.args[1])
+  rhs = deepcopy(ex.args[2])
 
-    lhs = deepcopy(ex.args[1])
-    rhs = deepcopy(ex.args[2])
+  # check lhs for exclusion criteria
+  if haskey(typealias_lhs_dict, lhs)
+    # record that symbol is now undefined
+    delete!(wc.common_buf, lhs)
+    return "# excluding lhs of  $ex"
+  end
 
-    # check lhs for exclusion criteria
-    if haskey(typealias_lhs_dict, lhs)
-      # record that symbol is now undefined
-      delete!(wc.common_buf, lhs)
-      return "# excluding lhs of  $ex"
-    end
+  # do non recursive replacement
+  rhs = get(typealias_single_dict, rhs, rhs)
 
-    # do non recursive replacement
-    rhs = get(typealias_single_dict, rhs, rhs)
+  if rhs == :Symbol
+    get!(ccall_rec_dict, lhs, :(Ptr{UInt8}))  # make the ccall argument a UInt8 recursive
+    get!(ccall_single_dict, lhs, :Cstring)  # make it a cstring for single level replacement
+    get!(symbol_type_dict, lhs, 1)  # record that this type is a symbol
+  end
 
-    if rhs == :Symbol
-      get!(ccall_rec_dict, lhs, :(Ptr{UInt8}))  # make the ccall argument a UInt8 recursive
-      get!(ccall_single_dict, lhs, :Cstring)  # make it a cstring for single level replacement
-      get!(symbol_type_dict, lhs, 1)  # record that this type is a symbol
-    end
+  # do recursive replacement
+  for i in keys(typealias_rec_dict)
+    rhs = replace_symbol(rhs, i, typealias_rec_dict[i])
+  end
 
-    # do recursive replacement
-    for i in keys(typealias_rec_dict)
-      rhs = replace_symbol(rhs, i, typealias_rec_dict[i])
-    end
-#=
-    if haskey(typealias_dict, ex.args[2]) && !haskey(typealias_dict, ex.args[1])
-      lhs = deepcopy(ex.args[1])
-      rhs = deepcopy(ex.args[2])
-      ex.args[2] = typealias_dict[ex.args[2]]
+  # check for undefined symbols
 
-      # update dictionaries so the typealias will be converted to the proper C type
-      rhs = get(ccall_dict, rhs, rhs)  # get a new rhs if it exists
-      get!(ccall_dict, lhs, rhs)  # store lhs -> rhs
-    end
-=#
-#=
-    # get rid of typealiases that we are not using
-    if haskey(type_dict, new_type)
-      delete!(wc.common_buf, new_type)  # record that the lhs symbol is now undefined
-      return "# omitting typealias $ex"
-    end
-=#
+  tmp = are_syms_defined(rhs)
+  if tmp != 0
+    delete!(wc.common_buf, lhs)  # record that the lhs symbol is now undefined
+    return "# skipping undefined typealias $ex"
+  end
 
-    # check for undefined symbols
+  # if no conditions met
+  # construct a new typealias
 
-    tmp = are_syms_defined(rhs)
-    if tmp != 0
-     delete!(wc.common_buf, lhs)  # record that the lhs symbol is now undefined
-     return "# skipping undefined typealias $ex"
-    end
-
-#=
-    ex2 = ex.args[2]
-    @assert ex2.head == :curly
-    str = string(ex2.args[2])  # get the pointee type name
-    println("str = ", str)
-    println("str[1] = ", str[1])
-    if str[1] == '_'  # if it begin with an underscore
-      println("rewriting typealias")
-      ex2.args[2] = :Void  # make it a Ptr{Void}
-      println("ex2 = ", ex2)
-      println("ex = ", ex)
-    end
-    # else do nothing
-=#
-
-   # if no conditions met
-   # construct a new typealias
-
-
-   return :(typealias $lhs $rhs)
+  return :(typealias $lhs $rhs)
 end
 
 # string processing
 function process_string(ex)
-
-#=
-  if ex[1] != '#'
-   println("modifying string")
-   return "# $ex"
-  end
-=#
   return "#= $ex =#"
 end
 
-
 ##### Type declaration functions #####
 function process_type(ex)
-
   # make all types (structs) immutable
   ex.args[1] = false
 
@@ -971,14 +698,10 @@ function process_type(ex)
   return ex
 end
 
-
 ##### Misc. functions ####
-
 function contains_symbol(ex, sym)
-# recursively check symbol in expression ex to see if sym is present
-
+  # recursively check symbol in expression ex to see if sym is present
   sum = 0
-
   if ex == sym
     return 1
   elseif typeof(ex) == Expr
@@ -993,77 +716,19 @@ function contains_symbol(ex, sym)
   return sum
 end
 
-
-#=
-function contains_symbol(ex, sym::Symbol)
-# do a recursive check to see if the expression ex contains a symbol
-
-  @assert typeof(ex) == Expr
-
-  sum = 0
-
-  if ex.head == :(::)  # if this expression is a type annotation
-    for i=1:length(ex.args)
-      if typeof(ex.args[i]) == Expr
-        sum += check_annot(ex.args[i], sym)
-
-      else  # this is a symbol
-#        println("    comparing ", ex.args[i], " to ", sym)
-        if ex.args[i] == sym
-#          println("comparison true")
-         return true
-        end
-#        println("comparison false")
-     end  # end if ... else
-    end  # end for
-
-  else  # keep recursing
-
-    for i=1:length(ex.args)
-      if typeof(ex.args[i]) == Expr
-#        println("  processing sub expression ", ex.args[i])
-        sum += contains_symbol(ex.args[i], sym)
-#        println("  sum = ", sum)
-      end  # else let this expression fall out of loop
-    end  # end loop over args
-
-  end  # end if ... else
-
-  return sum
-
-end
-=#
-
-
 function check_annot(ex, sym::Symbol)
-# check a type annotation
-
+  # check a type annotation
   for i=1:length(ex.args)
-#   println("  comparing ", ex.args[i], ", to ", sym)
-   if ex.args[i] == sym
-#    println("  comparison true")
-    return true
-   end
-#   println("  comparsion false")
+    if ex.args[i] == sym
+      return true
+    end
   end
-
   return false
 end
 
-
 function replace_symbol(ex, sym_old, sym_new)
-# do a recursive descent replace one symbol/expr with another
-
-#  @assert typeof(ex) == Expr
-#  println("receiving expression ", ex)
-#  println("typeof(ex) = ", typeof(ex))
-#  println("typeof(sym_old) = ", typeof(sym_old))
-#  println("typeof(sym_new) = ", typeof(sym_new))
-
-
-
   if ex == sym_old
-   return deepcopy(sym_new)
+    return deepcopy(sym_new)
   elseif typeof(ex) == Expr  # recurse the arguments
     for i=1:length(ex.args)
       ex.args[i] = replace_symbol(ex.args[i], sym_old,sym_new)
@@ -1075,110 +740,39 @@ function replace_symbol(ex, sym_old, sym_new)
   return deepcopy(ex)
 end
 
-
-#=
-
-  if typeof(ex) == Symbol  # if this is a symbol
-#      println("  found symbol ", ex)
-      if ex == sym_old
-#        println("  performing replacement ", ex, " with ", sym_new)
-        return sym_new
-      else
-#        println("  returning original symbol")
-        return ex
-      end
-   elseif typeof(ex)  == Expr  # keep recursing
-
-    for i=1:length(ex.args)
-#        println("  processing sub expression ", ex.args[i])
-#         println("  recursing expression ", ex.args[i])
-         tmp =  replace_symbol(ex.args[i], sym_old, sym_new)
-#         println("tmp = ", tmp)
-#         println("typeof(tmp) = ", typeof(tmp))
-#=
-         if typeof(tmp) == Expr
-           println("tmp.args = ", tmp.args)
-         end
-=#
-#         println("before assignment, ex.args[$i] = ", ex.args[i])
-#         println("before assignment, typeof(ex.args[$i]) = ", typeof(ex.args[i]))
-         if tmp != ex.args[i]
-           println("replacing ", ex.args[i], " with ", tmp)
-         end
-         ex.args[i] = tmp  # this shouldn't be necessary?
-
-#         println("after assignment typeof(ex.args[$i]) = ", typeof(ex.args[i]))
-    end  # end loop over args
-
- else # we don't know/care what this expression is
-    println("  not modify unknown expression ", ex)
-    return ex
-  end  # end if ... elseifa
-#=
-  println("Warning, got to end of replace_symbol")
-  println("typeof(ex) = ", typeof(ex))
-  println("ex.head = ", ex.head)
-  println("ex.args = ", ex.args)
-  println("ex = ", ex)
-  println("typeof(ex) = ", typeof(ex))
-=#
-  return ex
-
-end
-=#
-
-
-
 function count_depth(seed::Integer, ex)
-# primative attempt to count number of nodes on tree
-#  println("seed = ", seed)
+  # primitive attempt to count number of nodes on tree
   if typeof(ex) == Expr
     for i=1:length(ex.args)
 
       seed += count_depth(seed, ex.args[i])
     end
   else
-      println("ex = ", ex, " returning 1")
-      return 1
+    println("ex = ", ex, " returning 1")
+    return 1
   end
-
-#  println("at end, seed = ", seed)
   return seed
 end
 
 function are_syms_defined(ex)
-# check all symbols, see if they are defined by julia or by
-# the wrap contex
-
+  # check all symbols, see if they are defined by julia or by
+  # the wrap contex
   undefined_syms = 0  # approximate counter of undefined symbols found
 
   if typeof(ex)  == Expr  # keep recursing
-
     for i=1:length(ex.args)
-         undefined_syms +=  are_syms_defined(ex.args[i])
+      undefined_syms +=  are_syms_defined(ex.args[i])
     end  # end loop over args
-
-
   elseif typeof(ex) == Symbol  # if this is a symbol
-       if isdefined(ex) || haskey(wc.common_buf, ex) || haskey(const_defs, ex)
-         if isdefined(ex)
-           print("in Base ")
-         elseif haskey(wc.common_buf, ex)
-           print("in common_buf ")
-         end
-         println(ex, " is defined")
-
-         return 0  # symbol is defined
-       else
-         println(ex, " is not defined")
-        return 1
-       end
- else # we don't know/care what this expression is
+    if isdefined(ex) || haskey(wc.common_buf, ex) || haskey(const_defs, ex)
+      return 0  # symbol is defined
+    else
+      return 1
+    end
+  else # we don't know/care what this expression is
     println("  not counting unknown expression ", ex)
     return undefined_syms
   end  # end if ... elseifa
 
   return undefined_syms
-
 end
-#

--- a/src/generated/wrap_PETSc.jl
+++ b/src/generated/wrap_PETSc.jl
@@ -1,71 +1,46 @@
-#
-# Example script to wrap PETSc
-#
+# Script to wrap PETSc header files with Julia code
 
 using Clang_orig.cindex
 using Clang_orig.wrap_c
 using Compat
 
-
 import Clang_orig.wrap_c.repr_jl
 
 include("rewriter.jl")
-#=
-function repr_jl(ptr::cindex.Pointer)
-  ptee = pointee_type(ptr)
-  ex1 = Expr(:curly, :Ptr, repr_jl(ptee))
-  ex2 = Expr(:curly, :AbstractArray, repr_jl(ptee))
-  Expr(:curly, Union, ex1, ex2)
-end
-=#
 PETSC_INCLUDE = "../../deps/RealDouble/petsc-3.6.0/include"
-#PETSC_INCLUDE = "/home/jared/.julia/v0.4/PETSc/deps/petsc-3.6.0/arch-linux2-c-opt/include"
-#MPI_INCLUDE = "/usr/include/mpich"
-
-#petsc_header = [joinpath(PETSC_INCLUDE, "petscksp.h")]
 petsc_header = [joinpath(PETSC_INCLUDE, "petsc.h")]
-#h1 = "/usr/include"
 h1 = "/usr/lib/gcc/x86_64-linux-gnu/4.8/include"  # get some C datatype definitions like size_t
 h2 = joinpath(PETSC_INCLUDE, "petscsys.h")
-#h2 = joinpath(PETSC_INCLUDE, "petsc/mpiuni")
-#h3 = joinpath(PETSC_INCLUDE, "petsc/private")
-#h4 = joinpath(PETSC_INCLUDE, "petsc/private/kernels")
 
 # Set up include paths
 clang_includes = ASCIIString[]
 push!(clang_includes, PETSC_INCLUDE)
-#push!(clang_includes, MPI_INCLUDE)
 push!(clang_includes, h1)
 push!(clang_includes, h2)
-#push!(clang_includes, h3)
-#push!(clang_includes, h4)
 
 
 println("clang_includes = ", clang_includes)
+
 # Clang arguments
-#clang_extraargs = ["-v"]
- clang_extraargs = [ "-std=c99", "-D", "__STDC_LIMIT_MACROS", "-D", "__STDC_CONSTANT_MACROS", "-D", "PETSC_USE_REAL_SINGLE" ]
+clang_extraargs = [ "-std=c99", "-D", "__STDC_LIMIT_MACROS", "-D", "__STDC_CONSTANT_MACROS", "-D", "PETSC_USE_REAL_SINGLE" ]
 
 # Callback to test if a header should actually be wrapped (for exclusion)
 function wrap_header(top_hdr::ASCIIString, cursor_header::ASCIIString)
-#     return true
-    return startswith(dirname(cursor_header), PETSC_INCLUDE)
+  return startswith(dirname(cursor_header), PETSC_INCLUDE)
 end
 
 lib_file(hdr::ASCIIString) = "petsc"
 output_file(hdr::ASCIIString) = "PETSc.jl"
 
 function wrap_cursor(name::ASCIIString, cursor)
-    println("name = ", name)
-    exc = true
-    if length(name) > 0
-      if name[1] == '_'
-        exc = false
-      end
-#    exc = false
-#    exc |= contains(name, "MPI")
+  println("name = ", name)
+  exc = true
+  if length(name) > 0
+    if name[1] == '_'
+      exc = false
     end
-    return exc
+  end
+  return exc
 end
 
 const wc = wrap_c.init(;

--- a/src/mat.jl
+++ b/src/mat.jl
@@ -2,41 +2,41 @@
 export Mat, petscview
 #typealias pMat Ptr{Void} # Mat arguments in Petsc are pointers
 type Mat{T, MType} <: AbstractSparseMatrix{T,PetscInt}
-    p::C.Mat{T}
-    assembling::Bool # whether we are in the middle of assemble(vec) do ..
-    insertmode::C.InsertMode # current mode for setindex!
-    data::Any # keep a reference to anything needed for the Mat
-              # -- needed if the Mat is a wrapper around a Julia object,
-              #    to prevent the object from being garbage collected.
-    function Mat(p::C.Mat{T}, data=nothing)
-        A = new(p, false, C.INSERT_VALUES, data)
-        chk(C.MatSetType(p, MType))
-        finalizer(A, MatDestroy)
-        return A
-    end
+  p::C.Mat{T}
+  assembling::Bool # whether we are in the middle of assemble(vec)
+  insertmode::C.InsertMode # current mode for setindex!
+  data::Any # keep a reference to anything needed for the Mat
+            # -- needed if the Mat is a wrapper around a Julia object,
+            #    to prevent the object from being garbage collected.
+  function Mat(p::C.Mat{T}, data=nothing)
+    A = new(p, false, C.INSERT_VALUES, data)
+    chk(C.MatSetType(p, MType))
+    finalizer(A, MatDestroy)
+    return A
+  end
 end
 
 comm{T}(a::Mat{T}) = MPI.Comm(C.PetscObjectComm(T, a.p.pobj))
 
 function Mat{T}(::Type{T}, mtype=C.MatType=C.MATSEQ; comm=MPI.COMM_WORLD)
-    p = Ref{C.Mat{T}}()
-    chk(C.MatCreate(comm, p))
-    Mat{T, mtype}(p[])
+  p = Ref{C.Mat{T}}()
+  chk(C.MatCreate(comm, p))
+  Mat{T, mtype}(p[])
 end
 
 function Mat{T}(::Type{T}, m::Integer, n::Integer;
-    mlocal::Integer=C.PETSC_DECIDE, nlocal::Integer=C.PETSC_DECIDE,
-    nz::Integer=16, nnz::AbstractVector=PetscInt[],
-    onz::Integer=0, onnz::AbstractVector=PetscInt[],
-    comm=MPI.COMM_WORLD,
-    mtype::Symbol=C.MATMPIAIJ)
+  mlocal::Integer=C.PETSC_DECIDE, nlocal::Integer=C.PETSC_DECIDE,
+  nz::Integer=16, nnz::AbstractVector=PetscInt[],
+  onz::Integer=0, onnz::AbstractVector=PetscInt[],
+  comm=MPI.COMM_WORLD,
+  mtype::Symbol=C.MATMPIAIJ)
 
-    mat = Mat(T, mtype, comm=comm)
-    resize!(mat, m, n, mlocal=mlocal, nlocal=nlocal)
-    setpreallocation!(mat, nz=nz, nnz=nnz, onz=onz, onnz=onnz)
-    setoption!(mat, C.MAT_ROW_ORIENTED, false)  # julia data is column major
+  mat = Mat(T, mtype, comm=comm)
+  resize!(mat, m, n, mlocal=mlocal, nlocal=nlocal)
+  setpreallocation!(mat, nz=nz, nnz=nnz, onz=onz, onnz=onnz)
+  setoption!(mat, C.MAT_ROW_ORIENTED, false)  # julia data is column major
 
-    return mat
+  return mat
 end
 
 function MatDestroy{T}(mat::Mat{T})
@@ -49,113 +49,113 @@ function petscview{T}(mat::Mat{T})
 end
 
 function setoption!(m::Mat, option::C.MatOption, val::Bool)
-    chk(C.MatSetOption(m.p, option, PetscBool(val)))
-    m
+  chk(C.MatSetOption(m.p, option, PetscBool(val)))
+  m
 end
 
 gettype{T,MT}(a::Mat{T,MT}) = MT
 
 function Base.resize!(a::Mat, m::Integer=C.PETSC_DECIDE, n::Integer=C.PETSC_DECIDE;
-                   mlocal::Integer=C.PETSC_DECIDE, nlocal::Integer=C.PETSC_DECIDE)
-    if m == mlocal == C.PETSC_DECIDE
-        throw(ArgumentError("either the global (m) or local (mlocal) #rows must be specified"))
-    end
-    if n == nlocal == C.PETSC_DECIDE
-        throw(ArgumentError("either the global (n) or local (nlocal) #cols must be specified"))
-    end
-    chk(C.MatSetSizes(a.p, mlocal, nlocal, m, n))
-    a
+  mlocal::Integer=C.PETSC_DECIDE, nlocal::Integer=C.PETSC_DECIDE)
+  if m == mlocal == C.PETSC_DECIDE
+    throw(ArgumentError("either the global (m) or local (mlocal) #rows must be specified"))
+  end
+  if n == nlocal == C.PETSC_DECIDE
+    throw(ArgumentError("either the global (n) or local (nlocal) #cols must be specified"))
+  end
+  chk(C.MatSetSizes(a.p, mlocal, nlocal, m, n))
+  a
 end
 
 function setpreallocation!{T, MType}(a::Mat{T, MType};
-                           nz::Integer=16, nnz::AbstractVector=PetscInt[],
-                           onz::Integer=0, onnz::AbstractVector=PetscInt[])
-    if MType == C.MATSEQAIJ
-        pnnz = if isempty(nnz)
-            Ptr{T}(0)
-        else
-            if length(nnz) != size(a,1)
-                throw(ArgumentError("length(nnz) must be # rows"))
-            end
-            isa(nnz,Vector{PetscInt}) ? nnz : PetscInt[ i for i in nnz ]
-        end
-        chk(C.MatSeqAIJSetPreallocation(a.p, nz, pnnz))
-    elseif MType == C.MATMPIAIJ
-        mlocal = sizelocal(a,1)
-        pnnz = if isempty(nnz)
-            Ptr{PetscInt}(0)
-        else
-            if length(nnz) != mlocal
-                throw(ArgumentError("length(nnz) must be # local rows"))
-            end
-            isa(nnz,Vector{PetscInt}) ? nnz : PetscInt[ i for i in nnz ]
-        end
-        ponnz = if isempty(onnz)
-            Ptr{PetscInt}(0)
-        else
-            if length(onnz) != mlocal
-                throw(ArgumentError("length(onnz) must be # local rows"))
-            end
-            isa(onnz,Vector{PetscInt}) ? onnz : PetscInt[ i for i in onnz ]
-        end
-        chk(C.MatMPIAIJSetPreallocation(a.p, nz, pnnz, onz, ponnz))
-    else # TODO
-        throw(ArgumentError("unsupported matrix type $T"))
+  nz::Integer=16, nnz::AbstractVector=PetscInt[],
+  onz::Integer=0, onnz::AbstractVector=PetscInt[])
+  if MType == C.MATSEQAIJ
+    pnnz = if isempty(nnz)
+      Ptr{T}(0)
+    else
+      if length(nnz) != size(a,1)
+        throw(ArgumentError("length(nnz) must be # rows"))
+      end
+      isa(nnz,Vector{PetscInt}) ? nnz : PetscInt[ i for i in nnz ]
     end
-    a
+    chk(C.MatSeqAIJSetPreallocation(a.p, nz, pnnz))
+  elseif MType == C.MATMPIAIJ
+    mlocal = sizelocal(a,1)
+    pnnz = if isempty(nnz)
+      Ptr{PetscInt}(0)
+    else
+      if length(nnz) != mlocal
+        throw(ArgumentError("length(nnz) must be # local rows"))
+      end
+      isa(nnz,Vector{PetscInt}) ? nnz : PetscInt[ i for i in nnz ]
+    end
+    ponnz = if isempty(onnz)
+      Ptr{PetscInt}(0)
+    else
+      if length(onnz) != mlocal
+        throw(ArgumentError("length(onnz) must be # local rows"))
+      end
+      isa(onnz,Vector{PetscInt}) ? onnz : PetscInt[ i for i in onnz ]
+    end
+    chk(C.MatMPIAIJSetPreallocation(a.p, nz, pnnz, onz, ponnz))
+  else # TODO
+    throw(ArgumentError("unsupported matrix type $T"))
+  end
+  a
 end
 
 # construct Vec for multiplication by a::Mat or transpose(a::Mat)
 const mat2vec = Dict{C.MatType, C.MatType}( :mpiaij => :aij, :seqaij => :seq )
 Vec{T2}(a::Mat{T2}, transposed=false) =
   transposed ? Vec(T, size(a,1), comm=comm(a), T=mat2vec[gettype(a)],
-                   mlocal=sizelocal(a,1)) :
-               Vec(T, size(a,2), comm=comm(a), T=mat2vec[gettype(a)],
-                   mlocal=sizelocal(a,2))
+  mlocal=sizelocal(a,1)) :
+  Vec(T, size(a,2), comm=comm(a), T=mat2vec[gettype(a)],
+  mlocal=sizelocal(a,2))
 
 #############################################################################
 Base.convert(::Type{C.Mat}, a::Mat) = a.p
 
 function Base.size(a::Mat)
-    m = Array(PetscInt, 1)
-    n = Array(PetscInt, 1)
-    chk(C.MatGetSize(a.p, m, n))
-    (Int(m[1]), Int(n[1]))
+  m = Array(PetscInt, 1)
+  n = Array(PetscInt, 1)
+  chk(C.MatGetSize(a.p, m, n))
+  (Int(m[1]), Int(n[1]))
 end
 
 function sizelocal(a::Mat)
-    m = Array(PetscInt, 1)
-    n = Array(PetscInt, 1)
-    chk(C.MatGetLocalSize(a.p, m, n))
-    (Int(m[1]), Int(n[1]))
+  m = Array(PetscInt, 1)
+  n = Array(PetscInt, 1)
+  chk(C.MatGetLocalSize(a.p, m, n))
+  (Int(m[1]), Int(n[1]))
 end
 
 lengthlocal(a::Mat) = prod(sizelocal(a))
 
 # this causes the assembly state of the underlying petsc matrix to be copied
 function Base.similar{T, MType}(a::Mat{T, MType})
-    p = Array(C.Mat{T}, 1)
-    chk(C.MatDuplicate(a.p, C.MAT_DO_NOT_COPY_VALUES, p))
-    Mat{T, MType}(p[1])
+  p = Array(C.Mat{T}, 1)
+  chk(C.MatDuplicate(a.p, C.MAT_DO_NOT_COPY_VALUES, p))
+  Mat{T, MType}(p[1])
 end
 
 Base.similar{T}(a::Mat{T}, ::Type{T}) = similar(a)
 Base.similar{T,MType}(a::Mat{T,MType}, T2::Type) =
-    Mat(T2, size(a)..., comm=comm(a), mtype=MType)
+Mat(T2, size(a)..., comm=comm(a), mtype=MType)
 Base.similar{T,MType}(a::Mat{T,MType}, T2::Type, m::Integer, n::Integer) =
-    (m,n) == size(a) && T2==T ? similar(a) : Mat(T2, m,n, comm=comm(a), mtype=MType)
+(m,n) == size(a) && T2==T ? similar(a) : Mat(T2, m,n, comm=comm(a), mtype=MType)
 Base.similar(a::Mat, T::Type, Dims) = similar(a, T, d...)
 
 function Base.copy{T,MType}(a::Mat{T,MType})
-    p = Array(C.Mat{T}, 1)
-    chk(C.MatDuplicate(a.p, C.MAT_COPY_VALUES, p))
-    Mat{T,MType}(p[1])
+  p = Array(C.Mat{T}, 1)
+  chk(C.MatDuplicate(a.p, C.MAT_COPY_VALUES, p))
+  Mat{T,MType}(p[1])
 end
 
 function getinfo(m::Mat, infotype::Integer=C.MAT_GLOBAL_SUM)
-    info = Array(C.MatInfo,1)
-    chk(C.MatGetInfo(m.p, C.MatInfoType(infotype), info))
-    info[1]
+  info = Array(C.MatInfo,1)
+  chk(C.MatGetInfo(m.p, C.MatInfoType(infotype), info))
+  info[1]
 end
 
 Base.nnz(m::Mat) = int(getinfo(m).nz_used)
@@ -174,37 +174,37 @@ function AssemblyEnd(x::Mat, t::C.MatAssemblyType=C.MAT_FLUSH_ASSEMBLY)
 end
 
 function isassembled(x::Mat)
-    if x.assembling
-        return false
-    else
-        b = Array(PetscBool, 1)
-        chk(C.MatAssembled( x.p, b))
-        return b[1] != 0
-    end
+  if x.assembling
+    return false
+  else
+    b = Array(PetscBool, 1)
+    chk(C.MatAssembled( x.p, b))
+    return b[1] != 0
+  end
 end
 
 function assemble(f::Function, x::Union{Vec,Mat},
-                  insertmode=x.insertmode,
-                  assemblytype::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
-    if x.insertmode != insertmode && x.assembling
-        error("nested assemble with different insertmodes not allowed")
+  insertmode=x.insertmode,
+  assemblytype::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
+  if x.insertmode != insertmode && x.assembling
+    error("nested assemble with different insertmodes not allowed")
+  end
+  old_assembling = x.assembling
+  old_insertmode = x.insertmode
+  try
+    x.assembling = true
+    x.insertmode = insertmode
+    result = f()
+    if !old_assembling # don't Assemble if we are in nested assemble
+      AssemblyBegin(x, assemblytype)
+      yield() # do async computations while messages are in transit
+      AssemblyEnd(x, assemblytype)
     end
-    old_assembling = x.assembling
-    old_insertmode = x.insertmode
-    try
-        x.assembling = true
-        x.insertmode = insertmode
-        result = f()
-        if !old_assembling # don't Assemble if we are in nested assemble
-            AssemblyBegin(x, assemblytype)
-            yield() # do async computations while messages are in transit
-            AssemblyEnd(x, assemblytype)
-        end
-        return result
-    finally
-        x.assembling = old_assembling
-        x.insertmode = old_insertmode
-    end
+    return result
+  finally
+    x.assembling = old_assembling
+    x.insertmode = old_insertmode
+  end
 end
 
 # finalize matrix assembly
@@ -213,105 +213,105 @@ assemble(x::Union{Vec,Mat}) = assemble(() -> nothing, x)
 # intermediate assembly, before it is finally compressed for use
 iassemble(x::Union{Vec,Mat}) = assemble(() -> nothing, x, x.insertmode, C.MAT_FLUSH_ASSEMBLY)
 iassemble(f::Function, x::Mat, insertmode=x.insertmode) =
-    assemble(f, x, insertmode, C.MAT_FLUSH_ASSEMBLY)
+assemble(f, x, insertmode, C.MAT_FLUSH_ASSEMBLY)
 
 # like x[i,j] = v, but requires i,j to be 0-based indices for Petsc
 function setindex0!{T}(x::Mat{T}, v::Array{T},
-                       i::Array{PetscInt}, j::Array{PetscInt})
-    ni = length(i)
-    nj = length(j)
-    if length(v) != ni*nj
-        throw(ArgumentError("length(values) != length(indices)"))
-    end
-    chk(C.MatSetValues(x.p, ni, i, nj, j, v, x.insertmode))
-    if !x.assembling
-        AssemblyBegin(x,C.MAT_FLUSH_ASSEMBLY)
-        AssemblyEnd(x,C.MAT_FLUSH_ASSEMBLY)
-    end
-    x
+  i::Array{PetscInt}, j::Array{PetscInt})
+  ni = length(i)
+  nj = length(j)
+  if length(v) != ni*nj
+    throw(ArgumentError("length(values) != length(indices)"))
+  end
+  chk(C.MatSetValues(x.p, ni, i, nj, j, v, x.insertmode))
+  if !x.assembling
+    AssemblyBegin(x,C.MAT_FLUSH_ASSEMBLY)
+    AssemblyEnd(x,C.MAT_FLUSH_ASSEMBLY)
+  end
+  x
 end
 
 import Base: setindex!
 
 function setindex!{T}(x::Mat{T}, v::Number, i::Integer, j::Integer)
-    # can't call MatSetValue since that is a static inline function
-    setindex0!(x, T[ v ],
-               PetscInt[ i - 1 ],
-               PetscInt[ j - 1 ])
-    v
+  # can't call MatSetValue since that is a static inline function
+  setindex0!(x, T[ v ],
+  PetscInt[ i - 1 ],
+  PetscInt[ j - 1 ])
+  v
 end
 function setindex!{T3, T1<:Integer, T2<:Integer}(x::Mat{T3}, v::Array{T3},
-                                                 I::AbstractArray{T1},
-                                                 J::AbstractArray{T2})
-    I0 = PetscInt[ i-1 for i in I ]
-    J0 = PetscInt[ j-1 for j in J ]
-    setindex0!(x, v, I0, J0)
+  I::AbstractArray{T1},
+  J::AbstractArray{T2})
+  I0 = PetscInt[ i-1 for i in I ]
+  J0 = PetscInt[ j-1 for j in J ]
+  setindex0!(x, v, I0, J0)
 end
 function setindex!{T2, T<:Integer}(x::Mat{T2}, v::Array{T2},
-                                   i::Integer, J::AbstractArray{T})
-    I0 = PetscInt[ i-1 ]
-    J0 = PetscInt[ j-1 for j in J ]
-    setindex0!(x, v, I0, J0)
+  i::Integer, J::AbstractArray{T})
+  I0 = PetscInt[ i-1 ]
+  J0 = PetscInt[ j-1 for j in J ]
+  setindex0!(x, v, I0, J0)
 end
 function setindex!{T2, T<:Real}(x::Mat{T2}, v::Array{T2},
-                                I::AbstractArray{T}, j::Integer)
-    I0 = PetscInt[ i-1 for i in I ]
-    J0 = PetscInt[ j-1 ]
-    setindex0!(x, v, I0, J0)
+  I::AbstractArray{T}, j::Integer)
+  I0 = PetscInt[ i-1 for i in I ]
+  J0 = PetscInt[ j-1 ]
+  setindex0!(x, v, I0, J0)
 end
 
 setindex!{T1<:Integer, T2<:Integer}(x::Mat, v::Number,
-                                    I::AbstractArray{T1},
-                                    J::AbstractArray{T2}) = iassemble(x) do
-    for i in I
-        for j in J
-            x[i,j] = v
-        end
-    end
-    x
-end
-setindex!{T<:Integer}(x::Mat, v::Number,
-                      i::Integer, J::AbstractArray{T}) = iassemble(x) do
+I::AbstractArray{T1},
+J::AbstractArray{T2}) = iassemble(x) do
+  for i in I
     for j in J
-        x[i,j] = v
+      x[i,j] = v
     end
-    x
+  end
+  x
 end
 setindex!{T<:Integer}(x::Mat, v::Number,
-                      I::AbstractArray{T}, j::Integer) = iassemble(x) do
-    for i in I
-        x[i,j] = v
-    end
-    x
+i::Integer, J::AbstractArray{T}) = iassemble(x) do
+  for j in J
+    x[i,j] = v
+  end
+  x
+end
+setindex!{T<:Integer}(x::Mat, v::Number,
+I::AbstractArray{T}, j::Integer) = iassemble(x) do
+  for i in I
+    x[i,j] = v
+  end
+  x
 end
 
 function setindex!{T0<:Number, T1<:Integer, T2<:Integer}(x::Mat, v::AbstractArray{T0},
-                                                         I::AbstractArray{T1},
-                                                         J::AbstractArray{T2})
-    if length(v) != length(I)*length(J)
-        throw(ArgumentError("length(values) != length(indices)"))
-    end
-    v0 = eltype(Mat)[ z for z in v ]
-    setindex!(x, v0, I, J)
+  I::AbstractArray{T1},
+  J::AbstractArray{T2})
+  if length(v) != length(I)*length(J)
+    throw(ArgumentError("length(values) != length(indices)"))
+  end
+  v0 = eltype(Mat)[ z for z in v ]
+  setindex!(x, v0, I, J)
 end
 
 # fill! is not a very sensible function to call for sparse matrices,
 # but we might as well have it, especially for the v=0 case
 function Base.fill!(x::Mat, v::Number)
-    if v == 0
-        chk(C.MatZeroEntries(x.p))
-    else
-        # FIXME: only loop over local rows
-        iassemble(x) do
-            m,n = size(x)
-            for i in 1:m
-                for j in 1:n
-                    x[i,j] = v
-                end
-            end
+  if v == 0
+    chk(C.MatZeroEntries(x.p))
+  else
+    # FIXME: only loop over local rows
+    iassemble(x) do
+      m,n = size(x)
+      for i in 1:m
+        for j in 1:n
+          x[i,j] = v
         end
+      end
     end
-    return x
+  end
+  return x
 end
 
 #############################################################################
@@ -319,25 +319,24 @@ import Base.getindex
 
 # like getindex but for 0-based indices i and j
 function getindex0{T}(x::Mat{T}, i::Vector{PetscInt}, j::Vector{PetscInt})
-    ni = length(i)
-    nj = length(j)
-    v = Array(T, nj, ni) # row-major!
-    chk(C.MatGetValues(x.p, ni, i, nj, j, v))
-    ni <= 1 || nj <= 1 ? reshape(v, ni, nj) : transpose(v)
+  ni = length(i)
+  nj = length(j)
+  v = Array(T, nj, ni) # row-major!
+  chk(C.MatGetValues(x.p, ni, i, nj, j, v))
+  ni <= 1 || nj <= 1 ? reshape(v, ni, nj) : transpose(v)
 end
 
 getindex(a::Mat, i0::Integer, i1::Integer) =
-    getindex0(a, PetscInt[ i0-1 ], PetscInt[ i1-1 ])[1]
+  getindex0(a, PetscInt[ i0-1 ], PetscInt[ i1-1 ])[1]
 
-getindex{T0<:Integer,T1<:Integer}(a::Mat,
-                                  I0::AbstractArray{T0}, I1::AbstractArray{T1}) =
-    getindex0(a, PetscInt[ i0-1 for i0 in I0 ], PetscInt[ i1-1 for i1 in I1 ])
+getindex{T0<:Integer,T1<:Integer}(a::Mat, I0::AbstractArray{T0}, I1::AbstractArray{T1}) =
+  getindex0(a, PetscInt[ i0-1 for i0 in I0 ], PetscInt[ i1-1 for i1 in I1 ])
 
 getindex{T0<:Integer}(a::Mat, I0::AbstractArray{T0}, i1::Integer) =
-    reshape(getindex0(a, PetscInt[ i0-1 for i0 in I0 ], PetscInt[ i1-1 ]), length(I0))
+  reshape(getindex0(a, PetscInt[ i0-1 for i0 in I0 ], PetscInt[ i1-1 ]), length(I0))
 
 getindex{T1<:Integer}(a::Mat, i0::Integer, I1::AbstractArray{T1}) =
-    getindex0(a, PetscInt[ i0-1 ], PetscInt[ i1-1 for i1 in I1 ])
+  getindex0(a, PetscInt[ i0-1 ], PetscInt[ i1-1 for i1 in I1 ])
 
 #############################################################################
 # transposition etc.
@@ -345,43 +344,43 @@ getindex{T1<:Integer}(a::Mat, i0::Integer, I1::AbstractArray{T1}) =
 export MatTranspose
 
 function Base.full(a::Mat)
-    m,n = size(a)
-    a[1:m, 1:n]
+  m,n = size(a)
+  a[1:m, 1:n]
 end
 
 # create a new matrix wrapping around A for matrix-vector multiplication
 # but which does not actually require new storage
 for (f,pf) in ((:MatTranspose,:MatCreateTranspose), # acts like A.'
-               (:MatNormal, :MatCreateNormal))      # acts like A'*A
-    pfe = Expr(:quote, pf)
-    @eval function $f{T, MType}(a::Mat{T, MType})
-        p = Array(C.Mat{T}, 1)
-        chk(C.$pf(a.p, p))
-        Mat{T, MType}(p[1], a)
-    end
+  (:MatNormal, :MatCreateNormal))      # acts like A'*A
+  pfe = Expr(:quote, pf)
+  @eval function $f{T, MType}(a::Mat{T, MType})
+    p = Array(C.Mat{T}, 1)
+    chk(C.$pf(a.p, p))
+    Mat{T, MType}(p[1], a)
+  end
 end
 
 for (f,pf) in ((:transpose,:MatTranspose),(:ctranspose,:MatHermitianTranspose))
-    fb = symbol(string(f,"!"))
-    pfe = Expr(:quote, pf)
-    @eval begin
-        function Base.$fb(a::Mat)
-            pa = [a.p]
-            chk(C.$pf(a.p, C.MAT_REUSE_MATRIX, pa))
-            a
-        end
-
-        function Base.$f{T}(a::Mat{T})
-            p = Array(C.Mat{T}, 1)
-            chk(C.$pf(a.p, C.MAT_INITIAL_MATRIX, p))
-            Mat(p[1], comm=comm(a))
-        end
+  fb = symbol(string(f,"!"))
+  pfe = Expr(:quote, pf)
+  @eval begin
+    function Base.$fb(a::Mat)
+      pa = [a.p]
+      chk(C.$pf(a.p, C.MAT_REUSE_MATRIX, pa))
+      a
     end
+
+    function Base.$f{T}(a::Mat{T})
+      p = Array(C.Mat{T}, 1)
+      chk(C.$pf(a.p, C.MAT_INITIAL_MATRIX, p))
+      Mat(p[1], comm=comm(a))
+    end
+  end
 end
 
 function Base.conj!(a::Mat)
-    chk(C.MatConjugate(a.p))
-    a
+  chk(C.MatConjugate(a.p))
+  a
 end
 Base.conj(a::Mat) = conj!(copy(a))
 
@@ -391,8 +390,8 @@ Base.conj(a::Mat) = conj!(copy(a))
 # skip for now
 #=
 function chop!(x::Mat, tol::Real)
-    chk(ccall((:MatChop, petsc), PetscErrorCode, (pMat, PetscReal), x, tol))
-    x
+chk(ccall((:MatChop, petsc), PetscErrorCode, (pMat, PetscReal), x, tol))
+x
 end
 =#
 
@@ -423,11 +422,11 @@ function (*){T, MType}(A::Mat{T,MType}, B::Mat{T})
 end
 
 for (f,s) in ((:+,1), (:-,-1))
-    @eval function ($f){T}(A::Mat{T}, B::Mat{T})
-      Y = copy(A)
-      chk(C.MatAXPY(Y.p, T($s), B.p, C.DIFFERENT_NONZERO_PATTERN))
-      return Y
-    end
+  @eval function ($f){T}(A::Mat{T}, B::Mat{T})
+    Y = copy(A)
+    chk(C.MatAXPY(Y.p, T($s), B.p, C.DIFFERENT_NONZERO_PATTERN))
+    return Y
+  end
 end
 
 (-){T, MType}(A::Mat{T, MType}) = A * (-1)

--- a/src/petsc_com.jl
+++ b/src/petsc_com.jl
@@ -101,11 +101,10 @@ function PetscInitialize(lib::DataType, args,filename,help)
   return err
 end
 
-
 function petsc_sizeof(t::C.PetscDataType)
-    s = Array(Csize_t, 1)
-    chk(PetscDataTypeGetSize(C.petsc_type[1], t, s))
-    s[1]
+  s = Array(Csize_t, 1)
+  chk(PetscDataTypeGetSize(C.petsc_type[1], t, s))
+  s[1]
 end
 
 function PetscFinalized(T::Type)

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -4,30 +4,30 @@ export Vec, comm
 # T is data type
 # VType is type of vector from C.VecType
 type Vec{T,VType} <: AbstractVector{T}
-    p::C.Vec{T}
-    assembling::Bool # whether we are in the middle of assemble(vec) do ..
-    insertmode::C.InsertMode # current mode for setindex!
-    data::Any # keep a reference to anything needed for the Mat
-              # -- needed if the Mat is a wrapper around a Julia object,
-              #    to prevent the object from being garbage collected.
-    function Vec(p::C.Vec{T}, data=nothing)
-        v = new(p, false, C.INSERT_VALUES, data)
-        chk(C.VecSetType(p, VType))  # set the type here to ensure it matches VType
-        finalizer(v, VecDestroy)
-        return v
-    end
+  p::C.Vec{T}
+  assembling::Bool # whether we are in the middle of assemble(vec)
+  insertmode::C.InsertMode # current mode for setindex!
+  data::Any # keep a reference to anything needed for the Mat
+            # -- needed if the Mat is a wrapper around a Julia object,
+            #    to prevent the object from being garbage collected.
+  function Vec(p::C.Vec{T}, data=nothing)
+    v = new(p, false, C.INSERT_VALUES, data)
+    chk(C.VecSetType(p, VType))  # set the type here to ensure it matches VType
+    finalizer(v, VecDestroy)
+    return v
+  end
 end
 
 comm{T}(v::Vec{T}) = MPI.Comm(C.PetscObjectComm(T, v.p.pobj))
 
 function Vec{T}(::Type{T}, vtype::C.VecType=C.VECSEQ; comm=MPI.COMM_SELF)
-    p = Array(C.Vec{T}, 1)
-    chk(C.VecCreate(comm, p))
-    Vec{T, vtype}(p[1])
+  p = Array(C.Vec{T}, 1)
+  chk(C.VecCreate(comm, p))
+  Vec{T, vtype}(p[1])
 end
 
 function Vec{T<:Scalar}(::Type{T}, len::Integer, vtype::C.VecType=C.VECSEQ;
-                        comm=MPI.COMM_SELF, mlocal::Integer=C.PETSC_DECIDE)
+  comm=MPI.COMM_SELF, mlocal::Integer=C.PETSC_DECIDE)
   vec = Vec(T, vtype; comm=comm)
   resize!(vec, len, mlocal=mlocal)
   vec
@@ -35,10 +35,10 @@ end
 
 # make a Vec that is a wrapper around v, where v stores the local data
 function Vec{T<:Scalar}(v::Vector{T}; comm=MPI.COMM_SELF)
-    p = Array(C.Vec{T}, 1)
-    chk(C.VecCreateMPIWithArray(comm, 1, length(v), C.PETSC_DECIDE, v, p))
-    pv = Vec{T, C.VECMPI}(p[1], v)
-    return pv
+  p = Array(C.Vec{T}, 1)
+  chk(C.VecCreateMPIWithArray(comm, 1, length(v), C.PETSC_DECIDE, v, p))
+  pv = Vec{T, C.VECMPI}(p[1], v)
+  return pv
 end
 
 function VecDestroy{T}(vec::Vec{T})
@@ -55,11 +55,11 @@ export gettype
 gettype{T,VT}(a::Vec{T,VT}) = VT
 
 function Base.resize!(x::Vec, m::Integer=C.PETSC_DECIDE; mlocal::Integer=C.PETSC_DECIDE)
-    if m == mlocal == C.PETSC_DECIDE
-        throw(ArgumentError("either the length (m) or local length (mlocal) must be specified"))
-    end
-    chk(C.VecSetSizes(x.p, mlocal, m))
-    x
+  if m == mlocal == C.PETSC_DECIDE
+    throw(ArgumentError("either the length (m) or local length (mlocal) must be specified"))
+  end
+  chk(C.VecSetSizes(x.p, mlocal, m))
+  x
 end
 
 ##########################################################################
@@ -68,24 +68,24 @@ export lengthlocal, sizelocal, localpart
 Base.convert(::Type{C.Vec}, v::Vec) = v.p
 
 function Base.length(x::Vec)
-    sz = Array(PetscInt, 1)
-    chk(C.VecGetSize(x.p, sz))
-    Int(sz[1])
+  sz = Array(PetscInt, 1)
+  chk(C.VecGetSize(x.p, sz))
+  Int(sz[1])
 end
 Base.size(x::Vec) = (length(x),)
 
 function lengthlocal(x::Vec)
-    sz = Array(PetscInt, 1)
-    chk(C.VecGetLocalSize(x.p, sz))
-    sz[1]
+  sz = Array(PetscInt, 1)
+  chk(C.VecGetLocalSize(x.p, sz))
+  sz[1]
 end
 sizelocal(x::Vec) = (lengthlocal(x),)
 sizelocal{T,n}(t::AbstractArray{T,n}, d) = (d>n ? 1 : sizelocal(t)[d])
 
 function localpart(v::Vec)
-# this function returns a range from the first to the last indicies (1 based)
-# this is different than the Petsc VecGetOwnershipRange function where
-# the max value is one more than the number of entries
+  # this function returns a range from the first to the last indicies (1 based)
+  # this is different than the Petsc VecGetOwnershipRange function where
+  # the max value is one more than the number of entries
   low = Ref{PetscInt}()
   high = Ref{PetscInt}()
   chk(C.VecGetOwnershipRange(v.p, low, high))
@@ -93,29 +93,29 @@ function localpart(v::Vec)
 end
 
 function Base.similar{T,VType}(x::Vec{T,VType})
-    p = Array(C.Vec{T}, 1)
-    chk(C.VecDuplicate(x.p, p))
-    Vec{T,VType}(p[1])
+  p = Array(C.Vec{T}, 1)
+  chk(C.VecDuplicate(x.p, p))
+  Vec{T,VType}(p[1])
 end
 
 Base.similar{T}(x::Vec{T}, ::Type{T}) = similar(x)
 Base.similar{T,VType}(x::Vec{T,VType}, T2::Type) =
-    Vec(T2, length(x), VType; comm=comm(x), mlocal=lengthlocal(x))
+  Vec(T2, length(x), VType; comm=comm(x), mlocal=lengthlocal(x))
 
 function Base.similar{T,VType}(x::Vec{T,VType}, T2::Type, len::Union{Int,Dims})
-    length(len) == 1 || throw(ArgumentError("expecting 1-dimensional size"))
-    len==length(x) && T2==T ? similar(x) : Vec(T2, len, VType; comm=comm(x))
+  length(len) == 1 || throw(ArgumentError("expecting 1-dimensional size"))
+  len==length(x) && T2==T ? similar(x) : Vec(T2, len, VType; comm=comm(x))
 end
 
 function Base.similar{T,VType}(x::Vec{T,VType}, len::Union{Int,Dims})
-    length(len) == 1 || throw(ArgumentError("expecting 1-dimensional size"))
-    len==length(x) ? similar(x) : Vec(T, len, VType; comm=comm(x))
+  length(len) == 1 || throw(ArgumentError("expecting 1-dimensional size"))
+  len==length(x) ? similar(x) : Vec(T, len, VType; comm=comm(x))
 end
 
 function Base.copy(x::Vec)
-    y = similar(x)
-    chk(C.VecCopy(x.p, y.p))
-    y
+  y = similar(x)
+  chk(C.VecCopy(x.p, y.p))
+  y
 end
 
 ##########################################################################
@@ -125,7 +125,7 @@ export assemble, isassembled
 # for efficient vector assembly, put all calls to x[...] = ... inside
 # assemble(x) do ... end
 function AssemblyBegin(x::Vec, t::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
-# the t parameter is unused for vectors
+  # the t parameter is unused for vectors
   chk(C.VecAssemblyBegin(x.p))
 end
 
@@ -138,83 +138,83 @@ isassembled(x::Vec) = !x.assembling
 
 # like x[i] = v, but requires i to be 0-based indices for Petsc
 function setindex0!{T}(x::Vec{T}, v::Array{T}, i::Array{PetscInt})
-    n = length(v)
-    if n != length(i)
-        throw(ArgumentError("length(values) != length(indices)"))
-    end
-#    println("  in setindex0, passed bounds check")
-    chk(C.VecSetValues(x.p, n, i, v, x.insertmode))
-    if !x.assembling
-        AssemblyBegin(x)
-        AssemblyEnd(x)
-    end
-    x
+  n = length(v)
+  if n != length(i)
+    throw(ArgumentError("length(values) != length(indices)"))
+  end
+  #    println("  in setindex0, passed bounds check")
+  chk(C.VecSetValues(x.p, n, i, v, x.insertmode))
+  if !x.assembling
+    AssemblyBegin(x)
+    AssemblyEnd(x)
+  end
+  x
 end
 
 function setindex!{T}(x::Vec{T}, v::Number, i::Integer)
-    # can't call VecSetValue since that is a static inline function
-    setindex0!(x, T[ v ], PetscInt[ i - 1 ])
-    v
+  # can't call VecSetValue since that is a static inline function
+  setindex0!(x, T[ v ], PetscInt[ i - 1 ])
+  v
 end
 
 # set multiple entries to a single value
 setindex!{T<:Integer}(x::Vec, v::Number, I::AbstractArray{T}) = assemble(x) do
-    for i in I
-        x[i] = v
-    end
-    x
+  for i in I
+    x[i] = v
+  end
+  x
 end
 
 function Base.fill!{T}(x::Vec{T}, v::Number)
-    chk(C.VecSet(x.p, T(v)))
-    return x
+  chk(C.VecSet(x.p, T(v)))
+  return x
 end
 
 function setindex!{T<:Integer}(x::Vec, v::Number, I::Range{T})
-    if abs(step(I)) == 1 && minimum(I) == 1 && maximum(I) == length(x)
-        fill!(x, v)
-        return v
-    else
-        # use invoke here to avoid a recursion loop
-        return invoke(setindex!, (Vec,typeof(v),AbstractVector{T}), x,v,I)
-    end
+  if abs(step(I)) == 1 && minimum(I) == 1 && maximum(I) == length(x)
+    fill!(x, v)
+    return v
+  else
+    # use invoke here to avoid a recursion loop
+    return invoke(setindex!, (Vec,typeof(v),AbstractVector{T}), x,v,I)
+  end
 end
 
 setindex!{T<:Real}(x::Vec, V::AbstractArray, I::AbstractArray{T}) =
 assemble(x) do
-    if length(V) != length(I)
-        throw(ArgumentError("length(values) != length(indices)"))
-    end
-    # possibly faster to make a PetscScalar array from V, and
-    # a copy of the I array shifted by 1, to call setindex0! instead?
-    c = 1
-    for i in I
-        x[i] = V[c]
-        c += 1
-    end
-    x
+  if length(V) != length(I)
+    throw(ArgumentError("length(values) != length(indices)"))
+  end
+  # possibly faster to make a PetscScalar array from V, and
+  # a copy of the I array shifted by 1, to call setindex0! instead?
+  c = 1
+  for i in I
+    x[i] = V[c]
+    c += 1
+  end
+  x
 end
 
 # logical indexing
 setindex!(A::Vec, x::Number, I::AbstractArray{Bool}) = assemble(A) do
-    for i = 1:length(I)
-        if I[i]
-            A[i] = x
-        end
+  for i = 1:length(I)
+    if I[i]
+      A[i] = x
     end
-    A
+  end
+  A
 end
 for T in (:(Array{T2}),:(AbstractArray{T2})) # avoid method ambiguities
-    @eval setindex!{T2<:Scalar}(A::Vec, X::$T, I::AbstractArray{Bool}) = assemble(A) do
-        c = 1
-        for i = 1:length(I)
-            if I[i]
-                A[i] = X[c]
-                c += 1
-            end
-        end
-        A
+  @eval setindex!{T2<:Scalar}(A::Vec, X::$T, I::AbstractArray{Bool}) = assemble(A) do
+    c = 1
+    for i = 1:length(I)
+      if I[i]
+        A[i] = X[c]
+        c += 1
+      end
     end
+    A
+  end
 end
 
 ##########################################################################
@@ -222,9 +222,9 @@ import Base.getindex
 
 # like getindex but for 0-based indices i
 function getindex0{T}(x::Vec{T}, i::Vector{PetscInt})
-    v = similar(i, T)
-    chk(C.VecGetValues(x.p, length(i), i, v))
-    v
+  v = similar(i, T)
+  chk(C.VecGetValues(x.p, length(i), i, v))
+  v
 end
 
 getindex(x::Vec, i::Integer) = getindex0(x, PetscInt[i-1])[1]
@@ -237,129 +237,129 @@ getindex(x::Vec, I::AbstractVector{PetscInt}) =
 import Base: abs, exp, log, conj, conj!
 export abs!, exp!, log!
 for (f,pf) in ((:abs,:VecAbs), (:exp,:VecExp), (:log,:VecLog),
-               (:conj,:VecConjugate))
-    fb = symbol(string(f, "!"))
-    @eval begin
-        function $fb(x::Vec)
-            chk(C.$pf(x.p))
-            x
-        end
-        $f(x::Vec) = $fb(copy(x))
+  (:conj,:VecConjugate))
+  fb = symbol(string(f, "!"))
+  @eval begin
+    function $fb(x::Vec)
+      chk(C.$pf(x.p))
+      x
     end
+    $f(x::Vec) = $fb(copy(x))
+  end
 end
 
 # skip for now
 #=
 export chop!
 function chop!(x::Vec, tol::Real)
-    VecChop(x.c, tol)
-    chk(ccall((:VecChop, petsc), PetscErrorCode, (pVec, PetscReal), x, tol))
-    x
+VecChop(x.c, tol)
+chk(ccall((:VecChop, petsc), PetscErrorCode, (pVec, PetscReal), x, tol))
+x
 end
 =#
 
 for (f, pf, sf) in ((:findmax, :VecMax, :maximum), (:findmin, :VecMin, :minimum))
-    @eval begin
-        function Base.$f{T<:Real}(x::Vec{T})
-            i = Array(PetscInt, 1)
-            v = Array(T, 1)
-            chk(C.$pf(x.p, i, v))
-            (v[1], i[1]+1)
-        end
-        Base.$sf{T<:Real}(x::Vec{T}) = $f(x)[1]
+  @eval begin
+    function Base.$f{T<:Real}(x::Vec{T})
+      i = Array(PetscInt, 1)
+      v = Array(T, 1)
+      chk(C.$pf(x.p, i, v))
+      (v[1], i[1]+1)
     end
+    Base.$sf{T<:Real}(x::Vec{T}) = $f(x)[1]
+  end
 end
 # For complex numbers, VecMax and VecMin apparently return the max/min
 # real parts, which doesn't match Julia's maximum/minimum semantics.
 
 function Base.norm{T<:Real}(x::Union{Vec{T},Vec{Complex{T}}}, p::Number)
-    v = Array(T, 1)
-    n = p == 1 ? C.NORM_1 : p == 2 ? C.NORM_2 : p == Inf ? C.NORM_INFINITY :
-       throw(ArgumentError("unrecognized Petsc norm $p"))
-    chk(C.VecNorm(x.p, n, v))
-    v[1]
+  v = Array(T, 1)
+  n = p == 1 ? C.NORM_1 : p == 2 ? C.NORM_2 : p == Inf ? C.NORM_INFINITY :
+  throw(ArgumentError("unrecognized Petsc norm $p"))
+  chk(C.VecNorm(x.p, n, v))
+  v[1]
 end
 
 if VERSION >= v"0.5.0-dev+8353" # JuliaLang/julia#13681
-    import Base.normalize!
+  import Base.normalize!
 else
-    export normalize!
+  export normalize!
 end
 
 # computes v = norm(x,2), divides x by v, and returns v
 function normalize!{T<:Scalar}(x::Vec{T})
-    v = Array(T, 1)
-    chk(C.VecNormalize(x.p, v))
-    v[1]
+  v = Array(T, 1)
+  chk(C.VecNormalize(x.p, v))
+  v[1]
 end
 
 function Base.dot{T}(x::Vec{T}, y::Vec{T})
-    d = Array(T, 1)
-    chk(C.VecDot(y.p, x.p, d))
-    return d[1]
+  d = Array(T, 1)
+  chk(C.VecDot(y.p, x.p, d))
+  return d[1]
 end
 
 # unconjugated dot product (called for x'*y)
 function Base.At_mul_B{T<:Complex}(x::Vec{T}, y::Vec{T})
-    d = Array(T, 1)
-    chk(C.VecTDot(x.p, y.p, d))
-    return d
+  d = Array(T, 1)
+  chk(C.VecTDot(x.p, y.p, d))
+  return d
 end
 
 # pointwise operations on pairs of vectors (TODO: support in-place variants?)
 import Base: max, min, .*, ./, .\
 for (f,pf) in ((:max,:VecPointwiseMax), (:min,:VecPointwiseMin),
-               (:.*,:VecPointwiseMult), (:./,:VecPointwiseDivide))
-    @eval function ($f)(x::Vec, y::Vec)
-        w = similar(x)
-        chk(C.$pf(w.p, x.p, y.p))
-        w
-    end
+  (:.*,:VecPointwiseMult), (:./,:VecPointwiseDivide))
+  @eval function ($f)(x::Vec, y::Vec)
+    w = similar(x)
+    chk(C.$pf(w.p, x.p, y.p))
+    w
+  end
 end
 (.*)(x::Vec, a::Number...) = scale(x, prod(a))
 (.*)(a::Number, x::Vec) = scale(x, a)
 (./)(x::Vec, a::Number) = scale(x, inv(a))
 (.\)(a::Number, x::Vec) = scale(x, inv(a))
 function (./)(a::Number, x::Vec)
-    y = copy(x)
-    chk(C.VecReciprocal(y.p))
-    if a != 1.0
-        scale!(y, a)
-    end
-    y
+  y = copy(x)
+  chk(C.VecReciprocal(y.p))
+  if a != 1.0
+    scale!(y, a)
+  end
+  y
 end
 
 function Base.scale!{T}(x::Vec{T}, s::Number)
-    chk(C.VecScale(x.p, T(s)))
-    x
+  chk(C.VecScale(x.p, T(s)))
+  x
 end
 
 import Base: +, -, scale!
 function (+){T<:Scalar}(x::Vec{T}, a::Number...)
-    y = copy(x)
-    chk(C.VecShift(y.p, T(sum(a))))
-    return y
+  y = copy(x)
+  chk(C.VecShift(y.p, T(sum(a))))
+  return y
 end
 (+){T<:Scalar}(a::Number, x::Vec{T}) = x + a
 (-){T<:Scalar}(x::Vec{T}, a::Number) = x + (-a)
 (-)(x::Vec) = scale(x, -1)
 function (-){T<:Scalar}(a::Number, x::Vec{T})
-    y = -x
-    chk(C.VecShift(y.p, T(-a)))
-    return y
+  y = -x
+  chk(C.VecShift(y.p, T(-a)))
+  return y
 end
 
 import Base: ==
 function (==)(x::Vec, y::Vec)
-    b = Array(PetscBool,1)
-    chk(C.VecEqual(x.p, y.b, b))
-    b[1] != 0
+  b = Array(PetscBool,1)
+  chk(C.VecEqual(x.p, y.b, b))
+  b[1] != 0
 end
 
 function Base.sum{T}(x::Vec{T})
-    s = Array(T,1)
-    chk(C.VecSum(x.p, s))
-    s[1]
+  s = Array(T,1)
+  chk(C.VecSum(x.p, s))
+  s[1]
 end
 
 ##########################################################################
@@ -368,39 +368,39 @@ import Base.LinAlg.BLAS.axpy!
 
 # y <- alpha*x + y
 function axpy!{T}(alpha::Number, x::Vec{T}, y::Vec{T})
-    chk(C.VecAXPY(y.p, T(alpha), x.p))
-    y
+  chk(C.VecAXPY(y.p, T(alpha), x.p))
+  y
 end
 # w <- alpha*x + y
 function axpy!{T}(alpha::Number, x::Vec{T}, y::Vec{T}, w::Vec{T})
-    chk(C.VecWAXPY(w.p, T(alpha), x.p, y.p))
-    y
+  chk(C.VecWAXPY(w.p, T(alpha), x.p, y.p))
+  y
 end
 # y <- alpha*y + x
 function aypx!{T}(x::Vec{T}, alpha::Number, y::Vec{T})
-    chk(C.VecAYPX( y.p, T(alpha), x.p))
-    y
+  chk(C.VecAYPX( y.p, T(alpha), x.p))
+  y
 end
 # y <- alpha*x + beta*y
 function axpby!{T}(alpha::Number, x::Vec{T}, beta::Number, y::Vec{T})
-    chk(C.VecAXPBY(y.p, T(alpha), T(beta), x.p))
-    y
+  chk(C.VecAXPBY(y.p, T(alpha), T(beta), x.p))
+  y
 end
 # z <- alpha*x + beta*y + gamma*z
 function axpbypcz!{T}(alpha::Number, x::Vec{T}, beta::Number, y::Vec{T},
-                      gamma::Number, z::Vec{T})
-    chk(C.VecAXPBYPCZ(z.p, T(alpha), T(beta), T(gamma), x.p, y.p))
-    z
+  gamma::Number, z::Vec{T})
+  chk(C.VecAXPBYPCZ(z.p, T(alpha), T(beta), T(gamma), x.p, y.p))
+  z
 end
 
 # y <- y + \sum_i alpha[i] * x[i]
 function axpy!{V<:Vec}(y::V, alpha::AbstractArray, x::AbstractArray{V})
-    n = length(x)
-    length(alpha) == n || throw(BoundsError())
-    _x = [X.p for X in x]
-    _alpha = eltype(y)[a for a in alpha]
-    C.VecMAXPY(y.p, n, _alpha, _x)
-    y
+  n = length(x)
+  length(alpha) == n || throw(BoundsError())
+  _x = [X.p for X in x]
+  _alpha = eltype(y)[a for a in alpha]
+  C.VecMAXPY(y.p, n, _alpha, _x)
+  y
 end
 
 ##########################################################################
@@ -408,17 +408,17 @@ end
 import Base: .*, ./, .^, +, -
 
 for (f,pf) in ((:.*,:VecPointwiseMult), (:./,:VecPointwiseDivide), (:.^,:VecPow))
-    @eval function ($f)(x::Vec, y::Vec)
-        z = similar(x)
-        chk(C.$pf(z.p, x.p, y.p))
-        return z
-    end
+  @eval function ($f)(x::Vec, y::Vec)
+    z = similar(x)
+    chk(C.$pf(z.p, x.p, y.p))
+    return z
+  end
 end
 
 for (f,s) in ((:+,1), (:-,-1))
-    @eval function ($f){T}(x::Vec{T}, y::Vec{T})
-        z = similar(x)
-        chk(C.VecWAXPY(z.p, T($s), y.p, x.p))
-        return z
-    end
+  @eval function ($f){T}(x::Vec{T}, y::Vec{T})
+    z = similar(x)
+    chk(C.VecWAXPY(z.p, T($s), y.p, x.p))
+    return z
+  end
 end

--- a/test/is.jl
+++ b/test/is.jl
@@ -1,22 +1,22 @@
 # Test index sets and vector gather/scatter
 
 facts("\n --- Testing IS Functions ---") do
-    let i = IS(ST, 10:-2:1), j = sort(i)
-        @fact issorted(i) --> false
-        @fact issorted(j) --> true
-        @fact i == j --> true
-        @fact i ∪ j == i --> true
-        @fact Vector{Int}(i) --> [10:-2:1;]
-        @fact Vector{Int}(j) --> [2:2:10;]
-        @fact length(i) --> 5
-        @fact lengthlocal(i) --> 5
-        @fact minimum(i) --> 2
-        @fact maximum(i) --> 10
-        @fact Set(setdiff(i, IS(ST, 1:4))) --> Set(6:2:10)
-        @fact Set(union(i, IS(ST, [1,2,3,4]))) --> Set(2:2:10) ∪ Set(1:4)
-    end
+  let i = IS(ST, 10:-2:1), j = sort(i)
+    @fact issorted(i) --> false
+    @fact issorted(j) --> true
+    @fact i == j --> true
+    @fact i ∪ j == i --> true
+    @fact Vector{Int}(i) --> [10:-2:1;]
+    @fact Vector{Int}(j) --> [2:2:10;]
+    @fact length(i) --> 5
+    @fact lengthlocal(i) --> 5
+    @fact minimum(i) --> 2
+    @fact maximum(i) --> 10
+    @fact Set(setdiff(i, IS(ST, 1:4))) --> Set(6:2:10)
+    @fact Set(union(i, IS(ST, [1,2,3,4]))) --> Set(2:2:10) ∪ Set(1:4)
+  end
 
-    let x = Vec(ST[1,17,24,2]), y = Vec(ST, 2)
-        @fact scatter!(x, 2:3, y, 1:2) --> [17,24]
-    end
+  let x = Vec(ST[1,17,24,2]), y = Vec(ST, 2)
+    @fact scatter!(x, 2:3, y, 1:2) --> [17,24]
+  end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,5 @@
 using PETSc
-#PETSc.PetscInitialize()
 using FactCheck
-
-#import MPI
-#MPI.Init()
 
 # determine scalar type of current run
 global ST = Float64  # scalar type
@@ -39,7 +35,6 @@ function RC(x::AbstractArray)
 end
 
 for ST in [Float64, Float32, Complex128]
-#ST = Float64
   println("\n\nTesting ", ST)
   include("error.jl")
   include("vec.jl")
@@ -47,10 +42,3 @@ for ST in [Float64, Float32, Complex128]
   include("ksp.jl")
   include("is.jl")
 end
-
-
-# it looks like all the libraries share an MPI session, so we can only
-# finialize one of them
-#for ST in [Float64, Float32, Complex128]
-#  PETSc.C.PetscFinalize(ST)
-#end


### PR DESCRIPTION
Since @JaredCrean2 apparently prefers 2-space indentation, this PR edits the files to use that uniformly, rather than a mix of 2-space and 4-space indents.

(4-space indents are more common in Julia, and are used in Julia Base, but now that I'm using Atom and it auto-detects indentation settings in a file, I can live easily with either.  Jared, you might want to install [vim-sleuth](https://github.com/tpope/vim-sleuth) for similar capabilities using `vim`.)

I also deleted a bunch of commented-out code and debugging prints in rewriter.jl.   @JaredCrean2, you might want to read [this article about not living with "broken windows" in code](https://pragprog.com/the-pragmatic-programmer/extracts/software-entropy).