### PR TITLE
Added petscviews for KSP and PC, added BCGS test for KSP

### DIFF
--- a/src/ksp.jl
+++ b/src/ksp.jl
@@ -2,7 +2,7 @@
 # common options: Orthogonilization type, KSP type, PC type
 # use PC context created as part of KSP
 
-export KSP
+export KSP, petscview
 
 ###########################################################################
 
@@ -20,6 +20,11 @@ comm{T}(a::KSP{T}) = MPI.Comm(C.PetscObjectComm(T, a.p.pobj))
 
 function KSPDestroy{T}(o::KSP{T})
   PetscFinalized(T) || C.KSPDestroy(Ref(o.p))
+end
+
+function petscview{T}(o::KSP{T})
+  viewer = C.PetscViewer{T}(C_NULL)
+  chk(C.KSPView(o.p, viewer))
 end
 
 """

--- a/src/pc.jl
+++ b/src/pc.jl
@@ -1,4 +1,4 @@
-export PC
+export PC, petscview
 
 # preconditioner context
 type PC{T}
@@ -14,6 +14,11 @@ comm{T}(a::PC{T}) = MPI.Comm(C.PetscObjectComm(T, a.p.pobj))
 
 function PCDestroy{T}(o::PC{T})
   PetscFinalized(T) || C.PCDestroy(Ref(o.p))
+end
+
+function petscview{T}(o::PC{T})
+  viewer = C.PetscViewer{T}(C_NULL)
+  chk(C.PCView(o.p, viewer))
 end
 
 """

--- a/test/ksp.jl
+++ b/test/ksp.jl
@@ -18,10 +18,10 @@ facts("\nTesting KSP") do
   b[3] = RC(Complex(1,1))
   b_julia[3] = RC(Complex(1,1))
 
-  ksp = PETSc.KSP(A, ksp_monitor="")
+  kspg = PETSc.KSP(A, ksp_monitor="")
 
-  println("performing ksp solve")
-  x = ksp\b
+  println("performing ksp GMRES solve")
+  x = kspg\b
   println("finished ksp solve")
   x_julia = A_julia\b_julia
 
@@ -32,4 +32,20 @@ facts("\nTesting KSP") do
   println("A = ", A)
   println("b = ", b)
   println(" x = ", x)
+  println("ksp info:\n",petscview(kspg))
+
+  kspb = PETSc.KSP(A, ksp_type="bcgs", ksp_monitor="")
+  println("performing ksp BCGS solve")
+  x = kspb\b
+  println("finished ksp solve")
+  x_julia = A_julia\b_julia
+
+  for i=1:3
+    @fact x[i] --> roughly(x_julia[i])
+  end
+
+  println("A = ", A)
+  println("b = ", b)
+  println(" x = ", x)
+  println("ksp info:\n",petscview(kspb))
 end


### PR DESCRIPTION
Now the `test/ksp.jl` file shows how to set the solver type. I also added a viewer routine in the test, both to show that it actually does use `bijacobi` and so you can see some performance info. Added a `petscviewer` for `PC` as well, in case someone wants to inspect that.