### PR TITLE
make index assembling change

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,4 +4,6 @@ if isfile("deps.jl")
   rm("deps.jl")
 end
 
+Pkg.checkout("MPI", "master")
+Pkg.build("MPI")
 include("build_petscs.jl")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,6 +4,6 @@ if isfile("deps.jl")
   rm("deps.jl")
 end
 
-Pkg.checkout("MPI", "master")
-Pkg.build("MPI")
+#Pkg.checkout("MPI", "master")
+#Pkg.build("MPI")
 include("build_petscs.jl")

--- a/src/generated/PETScRealDouble.jl
+++ b/src/generated/PETScRealDouble.jl
@@ -572,7 +572,7 @@ function PetscObjectDestroy(arg0::Type{Float64},arg1::Union{Ptr{PetscObject},Str
     return err
 end
 
-function PetscObjectGetComm(arg0::Type{Float64},arg1::PetscObject,arg2::Union{Ptr{MPI_Comm},StridedArray{MPI_Comm},Ptr{MPI_Comm},Ref{MPI_Comm}})
+function PetscObjectGetComm(arg0::Type{Float64},arg1::Ptr{Void},arg2::Union{Ptr{MPI_Comm},StridedArray{MPI_Comm},Ptr{MPI_Comm},Ref{MPI.CComm}})
     err = ccall((:PetscObjectGetComm,petscRealDouble),PetscErrorCode,(PetscObject,Ptr{comm_type}),arg1,arg2)
     return err
 end

--- a/src/generated/defs.jl
+++ b/src/generated/defs.jl
@@ -17,7 +17,7 @@ const petsc_type = [Float64, Float32, Complex128]
 typealias Scalar Union{Float32, Float64, Complex128}
 
 const MPI_COMM_SELF = MPI.COMM_SELF
-typealias MPI_Comm MPI.Comm
+typealias MPI_Comm Union{MPI.CComm, MPI.Comm}
 typealias comm_type MPI.CComm
 
 # some auxiliary functions used by ccall wrappers

--- a/src/generated/rewriter.jl
+++ b/src/generated/rewriter.jl
@@ -568,6 +568,7 @@ function process_ccall(ex)
   # ...
   println("processing ccall ", ex)
   ex.args[1] = modify_libname(ex.args[1])  # change the library name
+  ex.args[2] = modify_rettype(ex.args[2]) # change return type
   ex.args[3] = modify_types(ex.args[3])
   println("changing argument names")
   ex3 = ex.args[3]  # get expression of argument types
@@ -576,6 +577,13 @@ function process_ccall(ex)
   @assert ex3.head == :tuple
 
   return ex
+end
+
+function modify_rettype(ex)
+
+  println("modifying return type")
+  println("ex = ", ex)
+  return deepcopy(ex)
 end
 
 function modify_types(ex)

--- a/src/ksp.jl
+++ b/src/ksp.jl
@@ -155,3 +155,11 @@ Base.size{T}(ksp::KSP{T}, dim::Integer) = dim > 2 ? 1 : size(ksp)[dim]
 
 import Base: \
 (\){T}(ksp::KSP{T}, b::Vec{T}) = A_ldiv_B!(ksp, b, similar(b, size(ksp, 2)))
+
+# Mat fallbacks
+(\){T}(A::Mat{T}, b::Vec{T}) = KSP(A)\b
+Base.A_ldiv_B!{T}(A::Mat{T}, b::Vec{T}, x::Vec{T}) = Base.A_ldiv_B!(KSP(A), b, x)
+
+KSPSolveTranspose{T}(A::Mat{T}, b::Vec{T}) = KSPSolveTranspose(KSP(A), b)
+KSPSolveTranspose{T}(A::Mat{T}, b::Vec{T}, x::Vec{T}) = KSPSOlveTranspose(KSP(A), x, b)
+

--- a/src/mat.jl
+++ b/src/mat.jl
@@ -543,7 +543,7 @@ function isassembled(x::PetscMat; local_only=false)
   val = isassembled(x.p)
   if !local_only
     if x.verify_assembled
-      val = MPI.Allreduce(Int32(val), MPI.LAND, comm(x))
+      val = MPI.Allreduce(Int8(val), MPI.LAND, comm(x))
     end
   end
 

--- a/src/mat.jl
+++ b/src/mat.jl
@@ -1,16 +1,25 @@
 # AbstractMatrix wrapper around Petsc Mat
 export Mat, petscview, SubMat
 
+"""
+  A Petsc matrix.
+
+  Unlike Vecs, the Petsc implementation keeps track of the local assembly 
+  state, so the Julia type does not have to.
+  `verify_assembled`: if true, verify all processes are assembled, if false,
+                      only local process
+  `insertmode`: C.InsertMode used by `setindex!`
+"""  
 abstract PetscMat{T, MType} <: AbstractSparseMatrix{T, PetscInt}
 type Mat{T, MType} <: PetscMat{T, MType}
   p::C.Mat{T}
-  assembled::Bool # whether we are in the middle of assemble(vec)
+  verify_assembled::Bool # check all processes assembled state or just current
   insertmode::C.InsertMode # current mode for setindex!
   data::Any # keep a reference to anything needed for the Mat
             # -- needed if the Mat is a wrapper around a Julia object,
             #    to prevent the object from being garbage collected.
-  function Mat(p::C.Mat{T}, data=nothing; first_instance::Bool=true)
-    A = new(p, false, C.INSERT_VALUES, data)
+  function Mat(p::C.Mat{T}, data=nothing; first_instance::Bool=true, verify_assembled=true)
+    A = new(p, verify_assembled, C.INSERT_VALUES, data)
     if first_instance  # if the pointer p has not been put into a Mat before
       chk(C.MatSetType(p, MType))
       finalizer(A, PetscDestroy)
@@ -22,7 +31,7 @@ end
 
 type SubMat{T, MType} <: PetscMat{T}
   p::C.Mat{T}
-  assembled::Bool # whether we are in the middle of assemble(vec)
+  verify_assembled::Bool
   insertmode::C.InsertMode # current mode for setindex!
   data::Any # keep a reference to anything needed for the Mat
             # -- needed if the Mat is a wrapper around a Julia object,
@@ -30,8 +39,8 @@ type SubMat{T, MType} <: PetscMat{T}
             # in general, we *must* keep a copy of the parent matrix, because
             # creating a submatrix does not increase the reference count
             # in Petsc (for some unknown reason)
-  function SubMat(p::C.Mat{T}, data=nothing)
-    A = new(p, false, C.INSERT_VALUES, data)
+  function SubMat(p::C.Mat{T}, data=nothing; verify_assembled=true)
+    A = new(p, verify_assembled, C.INSERT_VALUES, data)
     finalizer(A, SubMatRestore)
     return A
   end
@@ -105,7 +114,7 @@ function SubMat{T, MType}(mat::Mat{T, MType}, isrow::IS{T}, iscol::IS{T})
   submat = Ref{C.Mat{T}}()
   chk(C.MatGetLocalSubMatrix(mat.p, isrow.p, iscol.p, submat))
   # keep the data needed for the finalizer
-  return SubMat{T, MType}(submat[], (mat, isrow, iscol))  
+  return SubMat{T, MType}(submat[], (mat, isrow, iscol), verify_assembled=mat.verify_assembled)  
 end
 
 export SubMatRestore
@@ -501,6 +510,7 @@ Base.nnz(m::Mat) = Int(getinfo(m).nz_used)
 """
   Start assembling the matrix (the implmentations probably post 
   non-blocking sends and received)
+
 """
 function AssemblyBegin(x::PetscMat, t::C.MatAssemblyType=C.MAT_FLUSH_ASSEMBLY)
   chk(C.MatAssemblyBegin(x.p, t))
@@ -511,9 +521,6 @@ end
 """
 function AssemblyEnd(x::PetscMat, t::C.MatAssemblyType=C.MAT_FLUSH_ASSEMBLY)
   chk(C.MatAssemblyEnd(x.p, t))
-  if t == C.MAT_FINAL_ASSEMBLY
-    x.assembled = true
-  end
 end
 
 """
@@ -526,10 +533,22 @@ function isassembled(p::C.Mat)
 end
 
 """
-  Check if the matrix is assembled
+  Check if the matrix is assembled.  Whether all processes assembly state 
+  is checked or only the local process is determined by `x.verify_assembled`.
+
+  `local_only` forces only the local process to be checked, regardless of 
+  `x.verify_assembled`.
 """
-# why does this check x.assembling?
-isassembled(x::PetscMat) = x.assembled && isassembled(x.p)
+function isassembled(x::PetscMat; local_only=false)
+  val = isassembled(x.p)
+  if !local_only
+    if x.verify_assembled
+      val = MPI.Allreduce(Int32(val), MPI.LAND, comm(x))
+    end
+  end
+
+  return Bool(val)
+end
 
 """
   This function provides a mechanism for efficiently inserting values into
@@ -541,7 +560,7 @@ isassembled(x::PetscMat) = x.assembled && isassembled(x.p)
 function assemble(f::Function, x::Union{Vec,PetscMat},
   insertmode=x.insertmode,
   assemblytype::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
-  if x.insertmode != insertmode && !x.assembled
+  if x.insertmode != insertmode && !isassembled(x, local_only=true)
     error("nested assemble with different insertmodes not allowed")
   end
   old_insertmode = x.insertmode
@@ -562,8 +581,8 @@ end
   Assemble the Petsc object
 """
 function assemble(x::Union{Vec,PetscMat}, t::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
-    AssemblyBegin(x, t)
-    AssemblyEnd(x,t)
+  AssemblyBegin(x, t)
+  AssemblyEnd(x,t)
 end
 
 
@@ -597,7 +616,6 @@ function setindex0!{T}(x::Mat{T}, v::Array{T},
     throw(ArgumentError("length(values) != length(indices)"))
   end
   chk(C.MatSetValues(x.p, ni, i, nj, j, v, x.insertmode))
-  x.assembled = false
   x
 end
 
@@ -610,7 +628,6 @@ function setindex0!{T}(x::SubMat{T}, v::Array{T}, i::Array{PetscInt}, j::Array{P
     throw(ArgumentError("length(values) != length(indices)"))
   end
   chk(C.MatSetValuesLocal(x.p, ni, i, nj, j, v, x.insertmode))
-  x.assembled = false
   x
 end
 

--- a/src/ts.jl
+++ b/src/ts.jl
@@ -36,6 +36,13 @@ function isfinalized(ts::C.TS)
   return ts.pobj == C_NULL
 end
 
+#get the internal KSP object for this TS
+function KSP{T}(ts::TS{T})
+  ksp_c = Ref{C.KSP{T}}()
+  chk(C.TSGetKSP(ts.p, ksp_c))
+  return KSP{T}(ksp_c[])
+end
+
 """
   Most preferred constructor: taake ProblemType, method from options
   database

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -34,8 +34,27 @@ type Vec{T,VType} <: AbstractVector{T}
   end
 end
 
+import Base: show, showcompact
+function show(io::IO, x::Vec)
 
- """
+  myrank = MPI.Comm_rank(comm(x))
+  if myrank == 0
+    println("Petsc Vec of lenth ", length(x))
+  end
+  if isassembled(x)
+    println(io, "Process ", myrank, " entries:")
+    x_arr = LocalArrayRead(x)
+    show(io, x_arr)
+    LocalArrayRestore(x_arr)
+  else
+    println(io, "Process ", myrank, " not assembled")
+  end
+
+end
+
+
+showcompact(io::IO, x::Vec) = show(io, x)
+"""
   Null vectors, used in place of void pointers in the C
   API
 """

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -395,6 +395,7 @@ function isassembled(x::Vec, local_only=false)
     val = x.assembled
   end
 
+  println("val = ", val)
   return Bool(val)
 end
 

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -394,8 +394,6 @@ end
 function isassembled(x::Vec, local_only=false)
   myrank = MPI.Comm_rank(comm(x))
   if x.verify_assembled && !local_only
-    val1 = Int32(x.assembled)
-    commx = comm(x)
     val = MPI.Allreduce(Int8(x.assembled), MPI.LAND, comm(x))
   else
     val = x.assembled

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -388,8 +388,9 @@ end
   the local process to be checked, regardless of `x.verify_assembled`.
 """
 function isassembled(x::Vec, local_only=false)
-
+  myrank = MPI.Comm_rank(comm(x))
   if x.verify_assembled && !local_only
+    println("process", myrank, "Int(x.assembled) = ", Int32(x.assembled))
     val = MPI.Allreduce(Int32(x.assembled), MPI.LAND, comm(x))
   else
     val = x.assembled

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -1,7 +1,7 @@
 # AbstractVector wrapper around PETSc Vec types
 export Vec, comm, NullVec
 
-@doc """
+ """
   Construct a high level Vec object from a low level C.Vec.
   The data field is used to protect things from GC.
   A finalizer is attached to deallocate the memory of the underlying C.Vec, unless 
@@ -27,7 +27,7 @@ type Vec{T,VType} <: AbstractVector{T}
 end
 
 
-@doc """
+ """
   Null vectors, used in place of void pointers in the C
   API
 """
@@ -47,7 +47,7 @@ if have_petsc[3]
   NullVec[Complex128] = NullVec3
 
 end
-@doc """
+ """
   Gets the MPI communicator of a vector.
 """
 comm{T}(v::Vec{T}) = MPI.Comm(C.PetscObjectComm(T, v.p.pobj))
@@ -55,13 +55,13 @@ comm{T}(v::Vec{T}) = MPI.Comm(C.PetscObjectComm(T, v.p.pobj))
 
 export gettype
 
-@doc """
+ """
   Get the symbol that is the format of the vector
 """
 gettype{T,VT}(a::Vec{T,VT}) = VT
 
 
-@doc """
+ """
   Create an empty, unsized vector.
 """
 function Vec{T}(::Type{T}, vtype::C.VecType=C.VECMPI; 
@@ -71,7 +71,7 @@ function Vec{T}(::Type{T}, vtype::C.VecType=C.VECMPI;
   Vec{T, vtype}(p[])
 end
 
-@doc """
+ """
   Create a vector, specifying the (global) length len or the local length
   mlocal
 """
@@ -84,7 +84,7 @@ function Vec{T<:Scalar}(::Type{T}, len::Integer=C.PETSC_DECIDE;
   vec
 end
 
-@doc """
+ """
   Make a PETSc vector out of an array.  If used in parallel, the array becomes
   the local part of the PETSc vector
 """
@@ -99,7 +99,7 @@ end
 export VecGhost, VecLocal, restore
 
 
-@doc """
+ """
   Make a PETSc vector with space for ghost values.  ghost_idx are the 
   global indices that will be copied into the ghost space.
 """
@@ -123,7 +123,7 @@ function VecGhost{T<:Scalar, I <: Integer}(::Type{T}, mlocal::Integer,
     return Vec{T, C.VECMPI}(vref[])
 end
 
-@doc """
+ """
   Create a VECSEQ that contains both the local and the ghost values of the 
   original vector.  The underlying memory for the orignal and output vectors
   alias.
@@ -138,7 +138,7 @@ function VecLocal{T <:Scalar}( v::Vec{T, C.VECMPI})
 end
 
 #TODO: use restore for all types of restoring a local view
-@doc """
+ """
   Tell Petsc the VecLocal is no longer needed
 """
 function restore{T}(v::Vec{T, C.VECSEQ})
@@ -149,7 +149,7 @@ function restore{T}(v::Vec{T, C.VECSEQ})
 end
 
 
-@doc """
+ """
   The Petsc function to deallocate Vec objects
 """
 function PetscDestroy{T}(vec::Vec{T})
@@ -159,7 +159,7 @@ function PetscDestroy{T}(vec::Vec{T})
   end
 end
 
-@doc """
+ """
   Determine whether a vector has already been finalized
 """
 function isfinalized(vec::Vec)
@@ -172,7 +172,7 @@ end
 
 global const is_nullvec = isfinalized  # another name for doing the same check
 
-@doc """
+ """
   Use the PETSc routine for printing a vector to stdout
 """
 function petscview{T}(vec::Vec{T})
@@ -192,7 +192,7 @@ end
 ###############################################################################
 export ghost_begin!, ghost_end!, scatter!, ghost_update!
 # ghost vectors: essential methods
-@doc """
+ """
   Start communication to update the ghost values (on other processes) from the local
   values
 """
@@ -202,7 +202,7 @@ function ghost_begin!{T<:Scalar}(v::Vec{T, C.VECMPI}; imode=C.INSERT_VALUES,
     return v
 end
 
-@doc """
+ """
   Finish communication for updating ghost values
 """
 function ghost_end!{T<:Scalar}(v::Vec{T, C.VECMPI}; imode=C.INSERT_VALUES,
@@ -212,7 +212,7 @@ function ghost_end!{T<:Scalar}(v::Vec{T, C.VECMPI}; imode=C.INSERT_VALUES,
 end
 
 # ghost vectors: helpful methods
-@doc """
+ """
   Convenience method for calling both ghost_begin! and ghost_end!
 """
 function scatter!{T<:Scalar}(v::Vec{T, C.VECMPI}; imode=C.INSERT_VALUES, smode=C.SCATTER_FORWARD)
@@ -223,7 +223,7 @@ end
 
 # is there a way to specify all varargs must be same type?
 # this can't be named scatter! because of ambiguity with the index set scatter!
-@doc """
+ """
   Convenience method for calling ghost_begin! and ghost_end! for multiple vectors
 """
 function ghost_update!(v...; imode=C.INSERT_VALUES, smode=C.SCATTER_FORWARD)
@@ -247,7 +247,7 @@ export lengthlocal, sizelocal, localpart
 Base.convert(::Type{C.Vec}, v::Vec) = v.p
 
 import Base.length
-@doc """
+ """
   Get the global length of the vector
 """
 function length(x::Vec)
@@ -256,12 +256,12 @@ function length(x::Vec)
   Int(sz[])
 end
 
-@doc """
+ """
   Get the global size of the vector
 """
 Base.size(x::Vec) = (length(x),)
 
-@doc """
+ """
   Get the length of the local portion of the vector
 """
 function lengthlocal(x::Vec)
@@ -280,7 +280,7 @@ sizelocal(x::Vec) = (lengthlocal(x),)
 """
 sizelocal{T,n}(t::AbstractArray{T,n}, d) = (d>n ? 1 : sizelocal(t)[d])
 
-@doc """
+ """
   Get the range of global indices that define the local part of the vector.
   Internally, this calls the Petsc function VecGetOwnershipRange, and has
   the same limitations as that function, namely that some vector formats do 
@@ -328,7 +328,7 @@ export assemble, isassembled, AssemblyBegin, AssemblyEnd
 
 # for efficient vector assembly, put all calls to x[...] = ... inside
 # assemble(x) do ... end
-@doc """
+ """
   Start communication to assemble stashed values into the vector
 """
 function AssemblyBegin(x::Vec, t::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
@@ -336,20 +336,20 @@ function AssemblyBegin(x::Vec, t::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
   chk(C.VecAssemblyBegin(x.p))
 end
 
-@doc """
+ """
   Finish communication for assembling the vector
 """
 function AssemblyEnd(x::Vec, t::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
   chk(C.VecAssemblyEnd(x.p))
 end
 
-@doc """
+ """
   Check if a vector is assembled (ie. does not have stashed values)
 """
 isassembled(x::Vec) = !x.assembling
 # assemble(f::Function, x::Vec) is defined in mat.jl
 
-@doc """
+ """
   Like setindex, but requires the indices be 0-base
 """
 function setindex0!{T}(x::Vec{T}, v::Array{T}, i::Array{PetscInt})
@@ -499,7 +499,7 @@ else
   export normalize!
 end
 
-@doc """
+ """
   computes v = norm(x,2), divides x by v, and returns v
 """
 function normalize!{T<:Real}(x::Union{Vec{T},Vec{Complex{T}}})
@@ -664,7 +664,7 @@ end
 ##############################################################################
 export LocalArray, LocalArrayRead, LocalArrayRestore
 
-@doc """
+ """
   Object representing the local part of the array, accessing the memory directly.
   Supports all the same indexing as a regular Array
 """
@@ -683,7 +683,7 @@ type LocalArray{T <: Scalar} <: AbstractArray{T, 1}
 
 end
 
-@doc """
+ """
   Get the LocalArray of a vector.  Users must call LocalArrayRestore when
   finished updating the vector
 """
@@ -697,7 +697,7 @@ function LocalArray{T}(vec::Vec{T})
   return LocalArray{T}(a, ref, vec.p)
 end
 
-@doc """
+ """
   Tell Petsc the LocalArray is no longer being used
 """
 function LocalArrayRestore{T}(varr::LocalArray{T})
@@ -709,7 +709,7 @@ function LocalArrayRestore{T}(varr::LocalArray{T})
   varr.isfinalized = true
 end
 
-@doc """
+ """
   Get read-only access to the memory underlying a Petsc vector
 """
 type LocalArrayRead{T <: Scalar} <: AbstractArray{T, 1}
@@ -727,7 +727,7 @@ type LocalArrayRead{T <: Scalar} <: AbstractArray{T, 1}
 
 end
 
-@doc """
+ """
   Get the LocalArrayRead of a vector.  Users must call LocalArrayRestore when 
   finished with the object.
 """
@@ -750,7 +750,7 @@ function LocalArrayRestore{T}(varr::LocalArrayRead{T})
   varr.isfinalized = true
 end
 
-@doc """
+ """
   Typealias for both kinds of LocalArrays
 """
 typealias LocalArrays Union{LocalArray, LocalArrayRead}

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -34,7 +34,7 @@ type Vec{T,VType} <: AbstractVector{T}
   end
 end
 
-import Base: show, showcompact
+import Base: show, showcompact, writemime
 function show(io::IO, x::Vec)
 
   myrank = MPI.Comm_rank(comm(x))
@@ -54,6 +54,8 @@ end
 
 
 showcompact(io::IO, x::Vec) = show(io, x)
+writemime(io::IO, ::MIME"text/plain", x::Vec) = show(io, x)
+
 """
   Null vectors, used in place of void pointers in the C
   API

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -5,19 +5,27 @@ export Vec, comm, NullVec
   Construct a high level Vec object from a low level C.Vec.
   The data field is used to protect things from GC.
   A finalizer is attached to deallocate the memory of the underlying C.Vec, unless 
-  first_instance is set to true.
-  If assembling is false, then every call to setindex! also calls AssembleBegin and 
-  AssembleEnd.
+  `first_instance` is set to true.
+  `assembled` indicates when values are set via `setindex!` and is reset by
+   `AssemblyEnd`
+   `verify_assembled` when true, calls to `isassembled` verify all processes
+   have `assembled` = true, when false, only the local assembly state is 
+   checked.  This essentially makes the user responsible for assembling 
+  the vector before passing it into functions that will use it (like KSP
+  solves, etc.).
+
 """
 type Vec{T,VType} <: AbstractVector{T}
   p::C.Vec{T}
   assembled::Bool # whether are all values have been assembled
+  verify_assembled::Bool # check whether all processes are assembled
   insertmode::C.InsertMode # current mode for setindex!
   data::Any # keep a reference to anything needed for the Mat
             # -- needed if the Mat is a wrapper around a Julia object,
             #    to prevent the object from being garbage collected.
-  function Vec(p::C.Vec{T}, data=nothing; first_instance::Bool=true)
-    v = new(p, false, C.INSERT_VALUES, data)
+  function Vec(p::C.Vec{T}, data=nothing; first_instance::Bool=true, 
+               verify_assembled::Bool=true)
+    v = new(p, false, verify_assembled, C.INSERT_VALUES, data)
     if first_instance
       chk(C.VecSetType(p, VType))  # set the type here to ensure it matches VType
       finalizer(v, PetscDestroy)
@@ -334,7 +342,11 @@ export assemble, isassembled, AssemblyBegin, AssemblyEnd
   Start communication to assemble stashed values into the vector
 
   The MatAssemblyType is not needed for vectors, but is provided for 
-  compatability with the Mat case
+  compatability with the Mat case.
+
+  Unless vec.verify_assembled == false, users must *never* call the 
+  C functions VecAssemblyBegin, VecAssemblyEnd and VecSetValues, they must
+  call AssemblyBegin, AssemblyEnd, and setindex!.
 """
 function AssemblyBegin(x::Vec, t::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
   chk(C.VecAssemblyBegin(x.p))
@@ -349,9 +361,22 @@ function AssemblyEnd(x::Vec, t::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
 end
 
  """
-  Check if a vector is assembled (ie. does not have stashed values)
+  Check if a vector is assembled (ie. does not have stashed values).  If 
+  `x.verify_assembled`, the assembly state of all processes is checked, 
+  otherwise only the local process is checked. `local_only` forces only 
+  the local process to be checked, regardless of `x.verify_assembled`.
 """
-isassembled(x::Vec) = x.assembled
+function isassembled(x::Vec, local_only=false)
+
+  if x.verify_assembled && !local_only
+    val = MPI.Allreduce(Int32(x.assembled), MPI.LAND, comm(x))
+  else
+    val = x.assembled
+  end
+
+  return Bool(val)
+end
+
 # assemble(f::Function, x::Vec) is defined in mat.jl
 
  """

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -80,7 +80,8 @@ end
   Gets the MPI communicator of a vector.
 """
 function comm{T}(v::Vec{T})
-  ccomm = MPI.CComm(C.PetscObjectComm(T, v.p.pobj))
+  rcomm = Ref{MPI.CComm}()
+  ccomm = C.PetscObjectComm(T, v.p.pobj)
   fcomm = convert(MPI.Comm, ccomm)
   return fcomm
 end
@@ -394,20 +395,13 @@ end
 function isassembled(x::Vec, local_only=false)
   myrank = MPI.Comm_rank(comm(x))
   if x.verify_assembled && !local_only
-    println("process", myrank, " Int32(x.assembled) = ", Int32(x.assembled))
     val1 = Int32(x.assembled)
-    println("val = ", val1)
     commx = comm(x)
-    println("typeof(commx) = ", typeof(commx))
-    println("commx = ", commx)
-    println("comm_world = ", MPI.COMM_WORLD)
-    flush(STDOUT)
-    val = MPI.Allreduce(Int32(x.assembled), MPI.LAND, comm(x))
+    val = MPI.Allreduce(Int8(x.assembled), MPI.LAND, comm(x))
   else
     val = x.assembled
   end
 
-  println("val = ", val)
   return Bool(val)
 end
 

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -79,7 +79,11 @@ end
  """
   Gets the MPI communicator of a vector.
 """
-comm{T}(v::Vec{T}) = MPI.Comm(C.PetscObjectComm(T, v.p.pobj))
+function comm{T}(v::Vec{T})
+  ccomm = MPI.CComm(C.PetscObjectComm(T, v.p.pobj))
+  fcomm = convert(MPI.Comm, ccomm)
+  return fcomm
+end
 
 
 export gettype
@@ -390,7 +394,14 @@ end
 function isassembled(x::Vec, local_only=false)
   myrank = MPI.Comm_rank(comm(x))
   if x.verify_assembled && !local_only
-    println("process", myrank, "Int(x.assembled) = ", Int32(x.assembled))
+    println("process", myrank, " Int32(x.assembled) = ", Int32(x.assembled))
+    val1 = Int32(x.assembled)
+    println("val = ", val1)
+    commx = comm(x)
+    println("typeof(commx) = ", typeof(commx))
+    println("commx = ", commx)
+    println("comm_world = ", MPI.COMM_WORLD)
+    flush(STDOUT)
     val = MPI.Allreduce(Int32(x.assembled), MPI.LAND, comm(x))
   else
     val = x.assembled

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -49,7 +49,6 @@ function show(io::IO, x::Vec)
   else
     println(io, "Process ", myrank, " not assembled")
   end
-
 end
 
 
@@ -386,7 +385,7 @@ function AssemblyEnd(x::Vec, t::C.MatAssemblyType=C.MAT_FINAL_ASSEMBLY)
   x.assembled = true
 end
 
- """
+"""
   Check if a vector is assembled (ie. does not have stashed values).  If 
   `x.verify_assembled`, the assembly state of all processes is checked, 
   otherwise only the local process is checked. `local_only` forces only 

--- a/test/ksp.jl
+++ b/test/ksp.jl
@@ -24,9 +24,16 @@
       x_julia = A_julia\b_julia
       @test x ≈ x_julia
 
+      x = A\b
+      @test x ≈ x_julia
+
       x = KSPSolveTranspose(kspg, b)
       x_julia = A_julia.'\b_julia
       @test x ≈ x_julia
+
+      x = KSPSolveTranspose(A, b)
+      @test x ≈ x_julia
+
 
       pc   = PETSc.PC(ST,comm=comm(kspg),pc_type="jacobi")
       PETSc.chk(PETSc.C.PCSetOperators(pc.p,A.p,A.p))

--- a/test/mat.jl
+++ b/test/mat.jl
@@ -127,10 +127,8 @@ end
     @test isassembled(mat)
 
     mat2 = similar(mat, ST, 4, 4)
-    mat2.assembling = false
     mat2[1,2] = vt1
     mat2[1,3] = vt2
-    mat2.assembling = false
     PETSc.assemble(mat2)
 
     @test mat2[1,2] == vt1
@@ -309,6 +307,7 @@ end
       end
       vec[i] = RC(complex(Float64(i), i))
       vecj[i] = RC(complex(Float64(i), i))
+      assemble(vec)
     end
 
     assemble(mata)

--- a/test/ts.jl
+++ b/test/ts.jl
@@ -39,7 +39,9 @@ ST = Float64
   u[2] = 1.0
 
   solve!(ts, u)
-
+  #not sure how to test this other than "doesn't explode everywhere"
+  ksp = KSP(ts)
+  
   # same as above, but using set_ic
   ts = TS(ST, PETSc.C.TS_LINEAR, PETSc.C.TSEULER)
 

--- a/test/vec.jl
+++ b/test/vec.jl
@@ -21,6 +21,7 @@
   vec2 = similar(vec,ST)
   PETSc.AssemblyBegin(vec2)
   PETSc.AssemblyEnd(vec2)
+
   @test isassembled(vec2)
   val2_ret = vec2[1]
 

--- a/test/vec.jl
+++ b/test/vec.jl
@@ -333,4 +333,25 @@
   let x = rand(ST, 7)
     @test Vec(x) == x
   end
+
+  @testset "map" begin
+    x = rand(3)
+    y = Vec(x)
+    map!(sin, x)
+    map!(sin, y)
+    @test x ≈ y
+    x2 = map(sin, x)
+    y2 = map(sin, y)
+    @test x2 ≈ y2
+
+    function myfunc(a, b)
+      return a + b
+    end
+
+    x3 = copy(x2)
+    y3 = copy(y2)
+    map!(myfunc, x3, x2, x)
+    map!(myfunc, y3, y2, y)
+    @test x3 ≈ y3
+  end
 end


### PR DESCRIPTION
The changes indexing to *not* call `AssemblyBegin` and `AssemblyEnd` after each `SetValues` call, because this causes deadlocks in parallel.  Now the user can call `SetValues` as many time as needed and call `AssemblyBegin`/`AssemblyEnd` afterwards.  This is also a performance benefit, because `AssemblyBegin` and `AssemblyEnd` do a lot of parallel communication.