### PR TITLE
Implement Map for Vectors

### DIFF
--- a/src/vec.jl
+++ b/src/vec.jl
@@ -602,21 +602,8 @@ end
 ###############################################################################
 # map and friends
 import Base: map!, map
-# this should be inhertied from base
-#=
-function map(f, c)
-  out = copy(c)
-  for (idx, val) in enumerate(c)
-    out_idx = similar(val)
-    map!(f, out_idx, val)
-    out[idx] = out_idx
-  end
+#map() should be inherited from base
 
-  return out
-end
-=#
-#TODO: c should be a varargs, but that makes it ambiguous with map! defined
-# below
 function map!(f, c)
   map!(f, c, c)
 end
@@ -630,7 +617,7 @@ function map!{T}(f, dest::Vec{T}, src::Vec)
     throw(ArgumentError("Length of dest must be >= src"))
   end
   if localpart(dest)[1] != localpart(src)[1]
-    throw(ArgumentError("Local length of dest must be >= src"))
+    throw(ArgumentError("start of local part of src and dest must be aligned"))
   end
 
   dest_arr = LocalArray(dest)

--- a/test/vec.jl
+++ b/test/vec.jl
@@ -340,12 +340,10 @@
     map!(sin, x)
     map!(sin, y)
     @test x ≈ y
-    println("finished first test")
     x2 = map(sin, x)
     y2 = map(sin, y)
     @test x2 ≈ y2
-    println("finished second test")
-#=
+
     function myfunc(a, b)
       return a + b
     end
@@ -355,7 +353,5 @@
     map!(myfunc, x3, x2, x)
     map!(myfunc, y3, y2, y)
     @test x3 ≈ y3
-    println("finished third test")
-=#
   end
 end

--- a/test/vec.jl
+++ b/test/vec.jl
@@ -333,4 +333,29 @@
   let x = rand(ST, 7)
     @test Vec(x) == x
   end
+
+  @testset "map" begin
+    x = rand(3)
+    y = Vec(x)
+    map!(sin, x)
+    map!(sin, y)
+    @test x ≈ y
+    println("finished first test")
+    x2 = map(sin, x)
+    y2 = map(sin, y)
+    @test x2 ≈ y2
+    println("finished second test")
+#=
+    function myfunc(a, b)
+      return a + b
+    end
+
+    x3 = copy(x2)
+    y3 = copy(y2)
+    map!(myfunc, x3, x2, x)
+    map!(myfunc, y3, y2, y)
+    @test x3 ≈ y3
+    println("finished third test")
+=#
+  end
 end


### PR DESCRIPTION
Implements `map` for Petsc vectors.  Each process applies the operation to the local part of the vector.  When there is more than 1 source vector, the implementation is a bit weird pending JuliaLang/julia#13651 being resolved, but it works.