### PR TITLE
Constructors2

### DIFF
--- a/src/mat.jl
+++ b/src/mat.jl
@@ -92,6 +92,59 @@ function Mat{T}(::Type{T}, m::Integer=C.PETSC_DECIDE, n::Integer=C.PETSC_DECIDE;
   return mat
 end
 
+"""
+  Make a MATSEQ Petsc matrix for a SparseMatrixCSC.  This preserve the 
+  sparsity pattern of the matrix
+"""
+function Mat{T}(A::SparseMatrixCSC{T})
+  m, n = size(A)
+
+  # count number of non-zeros in each row
+  nz = zeros(PetscInt, m)
+  for i=1:n  # loop over columns
+    idx_start = A.colptr[i]
+    idx_end = A.colptr[i+1]-1
+    for j=idx_start:idx_end
+      rownum = A.rowval[j]
+      nz[rownum] += 1
+    end
+  end
+
+  # create the matrix
+  PA = Mat(T, m, n, nnz=nz, mtype=C.MATSEQAIJ)
+
+  # copy values
+  # create array large enough to hold all values in a column
+  maxcol = 0
+  for i=1:n
+    nvals = A.colptr[i+1] - A.colptr[i]
+    if nvals > maxcol
+      maxcol = nvals
+    end
+  end
+  idx = Array(PetscInt, maxcol)
+  idy = PetscInt[0]
+  
+  for i=1:n
+    idy[1] = i-1
+    idx_start = A.colptr[i]
+    idx_end = A.colptr[i+1]-1
+    # convert indices to PetscInts, zero-based
+    pos=1
+    for j=idx_start:idx_end
+      idx[pos] = A.rowval[j] - 1
+      pos += 1
+    end
+
+    # get subarray of only the needed entries
+    idx_view = sub(idx, 1:(pos-1))
+    vals = sub(A.nzval, idx_start:idx_end)
+    set_values!(PA, idx_view, idy, vals)
+  end
+
+  return PA
+end
+
 
 """
   Gets the a submatrix that references the entries in the original matrix.
@@ -794,15 +847,16 @@ getindex{T1<:Integer}(a::PetscMat, i0::Integer, I1::AbstractArray{T1}) =
 
 #############################################################################
 # zero based indexing
+#TODO: in 0.5, use boundscheck macro to verify stride=1
 
 # global, non-block
-function set_values!{T <: Scalar}(x::Mat{T}, idxm::DenseArray{PetscInt}, idxn::DenseArray{PetscInt}, v::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values!{T <: Scalar}(x::Mat{T}, idxm::StridedVecOrMat{PetscInt}, idxn::StridedVecOrMat{PetscInt}, v::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
   # v should be m x n
 
   chk(C.MatSetValues(x.p, length(idxm), idxm, length(idxn), idxn, v, o))
 end
 
-function set_values!{T <: Scalar, I1 <: Integer, I2 <: Integer}(x::Mat{T}, idxm::DenseArray{I1}, idxn::DenseArray{I2}, v::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values!{T <: Scalar, I1 <: Integer, I2 <: Integer}(x::Mat{T}, idxm::StridedVecOrMat{I1}, idxn::StridedVecOrMat{I2}, v::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   _idxm = PetscInt[ i for i in idxm]
   _idxn = PetscInt[ i for i in idxn]
@@ -832,13 +886,13 @@ end
 
 
 # global, block
-function set_values_blocked!{T <: Scalar}(x::Mat{T}, idxm::DenseArray{PetscInt}, idxn::DenseArray{PetscInt}, v::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values_blocked!{T <: Scalar}(x::Mat{T}, idxm::StridedVecOrMat{PetscInt}, idxn::StridedVecOrMat{PetscInt}, v::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   # vals should be m*bs x n*bs
   chk(C.MatSetValuesBlocked(x.p, length(idxm), idxm, length(idxn), idxn, v, o))
 end
 
-function set_values_blocked!{T <: Scalar, I1 <: Integer, I2 <: Integer}(x::Mat{T}, idxm::DenseArray{I1}, idxn::DenseArray{I2}, v::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values_blocked!{T <: Scalar, I1 <: Integer, I2 <: Integer}(x::Mat{T}, idxm::StridedVecOrMat{I1}, idxn::StridedVecOrMat{I2}, v::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   _idxm = PetscInt[ i for i in idxm]
   _idxn = PetscInt[ i for i in idxn]
@@ -846,12 +900,12 @@ function set_values_blocked!{T <: Scalar, I1 <: Integer, I2 <: Integer}(x::Mat{T
 end
 
 # local, non-block
-function set_values_local!{T <: Scalar}(x::Mat{T}, idxm::DenseArray{PetscInt}, idxn::DenseArray{PetscInt}, v::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values_local!{T <: Scalar}(x::Mat{T}, idxm::StridedVecOrMat{PetscInt}, idxn::StridedVecOrMat{PetscInt}, v::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   chk(C.MatSetValuesLocal(x.p, length(idxm), idxm, length(idxn), idxn, v, o))
 end
 
-function set_values_local!{T <: Scalar, I1 <: Integer, I2 <: Integer}(x::Mat{T}, idxm::DenseArray{I1}, idxn::DenseArray{I2}, v::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values_local!{T <: Scalar, I1 <: Integer, I2 <: Integer}(x::Mat{T}, idxm::StridedVecOrMat{I1}, idxn::StridedVecOrMat{I2}, v::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   _idxm = PetscInt[ i for i in idxm]
   _idxn = PetscInt[ i for i in idxn]
@@ -864,12 +918,12 @@ function set_values_local!(x::Matrix, idxm::AbstractArray, idxn::AbstractArray, 
 end
 
 # local, block
-function set_values_blocked_local!{T <: Scalar}(x::Mat{T}, idxm::DenseArray{PetscInt}, idxn::DenseArray{PetscInt}, v::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values_blocked_local!{T <: Scalar}(x::Mat{T}, idxm::StridedVecOrMat{PetscInt}, idxn::StridedVecOrMat{PetscInt}, v::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   chk(C.MatSetValuesBlockedLocal(x.p, length(idxm), idxm, length(idxn), idxn, v, o))
 end
 
-function set_values_blocked_local!{T <: Scalar, I1 <: Integer, I2 <: Integer}(x::Mat{T}, idxm::DenseArray{I1}, idxn::DenseArray{I2}, v::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values_blocked_local!{T <: Scalar, I1 <: Integer, I2 <: Integer}(x::Mat{T}, idxm::StridedVecOrMat{I1}, idxn::StridedVecOrMat{I2}, v::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   _idxm = PetscInt[ i for i in idxm]
   _idxn = PetscInt[ i for i in idxn]
@@ -1073,4 +1127,24 @@ function (==){T}(A::PetscMat{T}, b::PetscMat{T})
   bool_arr = Ref{PetscBool}()
   chk(C.MatEqual(A.p, b.p, bool_arr))
   return bool_arr[] != 0
+end
+
+"""
+  Equality test for SparseMatrixCSC and PetscMat, SEQ only
+"""
+function (==){T}(A::PetscMat{T, C.MATSEQAIJ}, B::SparseMatrixCSC)
+  if size(A) != size(B)
+    throw(ArgumentError("Matrices must be same size"))
+  end
+
+  m, n = size(B)
+
+  isame = true
+  for i=1:n
+    for j=1:m
+      isame = isame && A[i, j] == B[i,j]
+    end
+  end
+
+  return isame
 end

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -613,14 +613,16 @@ getindex(x::Vec, I::AbstractVector{PetscInt}) =
 # 0-based (to avoid temporary copies)
 export set_values!, set_values_blocked!, set_values_local!, set_values_blocked_local!
 
-function set_values!{T <: Scalar}(x::Vec{T}, idxs::DenseArray{PetscInt}, 
-                                 vals::DenseArray{T}, o::C.InsertMode=x.insertmode)
+#TODO: in 0.5, use boundscheck macro to verify stride=1
+
+function set_values!{T <: Scalar}(x::Vec{T}, idxs::StridedVecOrMat{PetscInt}, 
+                                 vals::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   chk(C.VecSetValues(x.p, length(idxs), idxs, vals, o))
 end
 
-function set_values!{T <: Scalar, I <: Integer}(x::Vec{T}, idxs::DenseArray{I},
-                                         vals::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values!{T <: Scalar, I <: Integer}(x::Vec{T}, idxs::StridedVecOrMat{I},
+                                         vals::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   # convert idxs to PetscInt
   p_idxs = PetscInt[ i for i in idxs]
@@ -644,14 +646,14 @@ function set_values!(x::AbstractVector, idxs::AbstractArray, vals::AbstractArray
 end
 
 
-function set_values_blocked!{T <: Scalar}(x::Vec{T}, idxs::DenseArray{PetscInt},
-                                          vals::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values_blocked!{T <: Scalar}(x::Vec{T}, idxs::StridedVecOrMat{PetscInt},
+                                          vals::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   chk(C.VecSetValuesBlocked(x.p, length(idxs), idxs, vals, o))
 end
 
 function set_values_blocked!{T <: Scalar, I <: Integer}(x::Vec{T}, 
-                             idxs::DenseArray{I}, vals::DenseArray{T}, 
+                             idxs::StridedVecOrMat{I}, vals::StridedVecOrMat{T}, 
                              o::C.InsertMode=x.insertmode)
  
   p_idxs = PetscInt[ i for i in idxs]
@@ -661,14 +663,14 @@ end
 # julia doesn't have blocked vectors, so skip
 
 
-function set_values_local!{T <: Scalar}(x::Vec{T}, idxs::DenseArray{PetscInt},
-                                       vals::DenseArray{T}, o::C.InsertMode=x.insertmode)
+function set_values_local!{T <: Scalar}(x::Vec{T}, idxs::StridedVecOrMat{PetscInt},
+                                       vals::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   chk(C.VecSetValuesLocal(x.p, length(idxs), idxs, vals, o))
 end
 
 function set_values_local!{T <: Scalar, I <: Integer}(x::Vec{T}, 
-                           idxs::DenseArray{I}, vals::DenseArray{T}, 
+                           idxs::StridedVecOrMat{I}, vals::StridedVecOrMat{T}, 
                            o::C.InsertMode=x.insertmode)
 
   p_idxs = PetscInt[ i for i in idxs]
@@ -695,15 +697,15 @@ end
 
 
 function set_values_blocked_local!{T <: Scalar}(x::Vec{T}, 
-                                   idxs::DenseArray{PetscInt},
-                                   vals::DenseArray{T}, o::C.InsertMode=x.insertmode)
+                                   idxs::StridedVecOrMat{PetscInt},
+                                   vals::StridedVecOrMat{T}, o::C.InsertMode=x.insertmode)
 
   chk(C.VecSetValuesBlockedLocal(x.p, length(idxs), idxs, vals, o))
 end
 
 
 function set_values_blocked_local!{T <: Scalar, I <: Integer}(x::Vec{T}, 
-                           idxs::DenseArray{I}, vals::DenseArray{T}, 
+                           idxs::StridedVecOrMat{I}, vals::StridedVecOrMat{T}, 
                            o::C.InsertMode=x.insertmode)
 
   p_idxs = PetscInt[ i for i in idxs]

--- a/test/mat.jl
+++ b/test/mat.jl
@@ -354,13 +354,17 @@ end
       end
     end
 
-
-        
-
-
-
-
   end
+
+  @testset "Sparse Matrix conversion" begin
+    A = sprand(10, 10, 0.1)
+    B = Mat(A)
+    assemble(B)
+    @test A == B
+    info = PETSc.getinfo(B)
+    @test info.mallocs == 0
+  end
+
   @testset "test conversion of values to a new type" begin
     mata = PETSc.Mat(ST, 3, 3)
     matb = PETSc.Mat(ST, 3, 3)

--- a/test/mat.jl
+++ b/test/mat.jl
@@ -363,6 +363,13 @@ end
     @test A == B
     info = PETSc.getinfo(B)
     @test info.mallocs == 0
+
+    A2 = full(A)
+    B2 = Mat(B)
+    assemble(B2)
+    @test A2 == B2
+    info = PETSc.getinfo(B2)
+    @test info.mallocs == 0
   end
 
   @testset "test conversion of values to a new type" begin

--- a/test/mat.jl
+++ b/test/mat.jl
@@ -370,6 +370,16 @@ end
     @test A2 == B2
     info = PETSc.getinfo(B2)
     @test info.mallocs == 0
+
+    dtol = 1e-16
+    A3 = ST[1. 2 3; 4 5 6; 7 8 dtol/10]
+    B3 = Mat(A3, droptol=dtol)
+    assemble(B3)
+    A3b = copy(A3)
+    A3b[3, 3] = 0
+    @test A3b == B3
+    info = PETSc.getinfo(B3)
+    @test info.nz_used == 8
   end
 
   @testset "test conversion of values to a new type" begin


### PR DESCRIPTION
This allows constructing a sequential Petsc array from an `AbstractArray`, with a special case for `SparseMatrixCSC`.  

@stevengj this will enable doing `kron` or other operations on a Julia and then transferring the result to Petsc.  This is logically equivalent to doing `kron` on a Petsc matrix when the Petsc matrix can only be sequential, and is probably faster when doing repeated `kron`s because indexing Petsc arrays is quite slow.