### PR TITLE
[wip] Kron

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.4
 BaseTestNext
 Compat
+ArrayViews
 MPI

--- a/src/PETSc.jl
+++ b/src/PETSc.jl
@@ -2,6 +2,7 @@ module PETSc
 
 import MPI
 export PetscInt
+using ArrayViews
 include(joinpath("generated", "C.jl"))
 using .C
 include("petsc_com.jl")

--- a/src/generated/error.jl
+++ b/src/generated/error.jl
@@ -31,5 +31,9 @@ function PetscErrorMessage(errnum)
   C.PetscErrorMessage(C.petsc_type[1], errnum, msg_ptr, Ref{Ptr{UInt8}}(C_NULL))
   # error num strings are stored in a constant table so
   # the pointer does not have to be free'd here
-  return bytestring(msg_ptr[])
+  if msg_ptr[] == C_NULL
+    return "Petsc did not supply an error message"
+  else
+    return bytestring(msg_ptr[])
+  end
 end

--- a/src/mat.jl
+++ b/src/mat.jl
@@ -1436,6 +1436,7 @@ function PetscKron{T <: Scalar}(A::SparseMatrixCSC{T}, B::SparseMatrixCSC{T})
       vals_extract = unsafe_view(D_vals, 1:(pos-1))
       set_values!(D, rowidx_extract, D_colidx, vals_extract)
     end
+#    assemble(D, C.MAT_FLUSH_ASSEMBLY)
   end
 
   return D

--- a/test/mat.jl
+++ b/test/mat.jl
@@ -594,5 +594,40 @@ end
     Aj = sprand(m1, n1, 0.01)
     Bj = sprand(m2, n2, 0.01)
     testrun(Aj, Bj)
+
+    function testkron(Aj, Bj)
+      m1, n1 = size(Aj)
+      m2, n2 = size(Bj)
+      Cj = kron(Aj, Bj)
+      C = PETSc.PetscKron(Aj, Bj)
+      assemble(C)
+      C_full = C[1:(m1*m2), 1:(n1*n2)]
+      Cj_full = full(Cj)
+    #  @test Cj_full ≈ C_full
+    end
+    
+#    println("\n----- Case 1 -----")
+    Aj = sparse(eye(3, 3))
+    testkron(Aj, Aj) 
+
+#    println("\n----- Case 2 -----")
+    Aj = sparse([1. 2 0; 3 4 5; 0 6 7])
+    testkron(Aj, Aj)
+
+#    println("\n----- Case 3 -----")
+    Aj = sparse([1. 2 3; 4 5 6; 7 8 9])
+    Bj = sparse([10. 11 12 13; 14 15 16 17; 18 19 20 21])
+    testkron(Aj, Bj)
+
+#    println("\n----- Case 4 -----")
+    Aj = sparse([1. 2 ; 4 5 ; 7 8 ])
+    Bj = sparse([10. 11 12 13 22; 14 15 16 17 23; 18 19 20 21 24])
+    testkron(Aj, Bj)
+
+#    println("\n----- Case 5 -----")
+    Aj = sprand(10, 15, 0.01)
+    Bj = sprand(7, 21, 0.01)
+    testkron(Aj, Bj)
+
   end
 end

--- a/test/mat.jl
+++ b/test/mat.jl
@@ -546,4 +546,53 @@ end
     @test PETSc.count_row_nz(mat, 3) == 3
   end
 
+  @testset "kron" begin
+    function testrun(Aj, Bj)
+      # A and B are julia matrices of some kind
+      A = Mat(Aj); B = Mat(Bj)
+      assemble(A); assemble(B)
+      Cj = kron(Aj, Bj)
+      C = kron(A, B)
+      assemble(C)
+      m, n = size(C)
+      C2 = C[1:m, 1:n]
+      @test C2 ≈ Cj
+    end
+
+    # case 1
+    Aj = ST[1. 0 0; 0 1 0; 0 0 1]
+    testrun(Aj, Aj)
+
+    # case 2
+    Aj = ST[1. 2 0; 3 4 5; 0 6 7]
+    testrun(Aj, Aj)
+
+
+    n = 10
+    Aj = rand(ST, n, n)
+    testrun(Aj, Aj)
+
+
+    m = 3
+    n = 2
+    Aj = rand(ST, m, n)
+    testrun(Aj, Aj)
+
+
+    m1 = 3
+    n1 = 2
+    m2 = 4
+    n2 = 5
+    Aj = rand(ST, m1, n1)
+    Bj = rand(ST, m2, n2)
+    testrun(Aj, Bj)
+
+    m1 = 5
+    m2 = 7
+    n1 = 8
+    n2 = 10
+    Aj = sprand(m1, n1, 0.01)
+    Bj = sprand(m2, n2, 0.01)
+    testrun(Aj, Bj)
+  end
 end


### PR DESCRIPTION
Implements `kron` between two Petsc sequential matrices.  The original implementation was surprisingly slow, so I made `MatRow` immutable.  This helped with GC time (40% GC time -> 2% GC time), overall this `kron` is still 1-2 orders of magnitude slower than `kron` between 2 SparseMatrixCSCs.  I profiled, and it turns out the Petsc constructor and destructor for a `MatRow` are quite slow.  Almost all of the time is being spent there, so I don't think this is going to get any faster.   To ameliorate this, I will implement a `kron(A::SparseMatrixCSC, B::SparseMatrixCSC) -> Mat`