### PR TITLE
Allow for custom PETSc library builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,33 @@ The installation can be tested with
 ]test PETSc
 ```
 
-## Caveats
+## BinaryBuilder Version
 
 The package requires the uses a pre-build binary of
 [`PETSc`](https://github.com/JuliaBinaryWrappers/PETSc_jll.jl) along with a
 default installation of `MPI.jl`; use of system install MPI and PETSc is not
-currently supported.
+currently supported. Not that the distributed version of PETSc is using real,
+`Float64` numbers; build details can be found
+[here](https://github.com/JuliaPackaging/Yggdrasil/blob/master/P/PETSc/build_tarballs.jl)
+
+## System Builds
+
+If you want to use the package with custom builds of the PETSc library, this can
+be done by specifying the environment variable `JULIA_PETSC_LIBRARY`. This is a
+colon separated list of paths to custom builds of PETSc; the reason for using
+multiple builds is to enable single, double, and complex numbers in the same
+julia session. These should be built against the same version of MPI as used
+with `MPI.jl`
+
+After setting the variable you should
+```julia
+]build PETSc
+```
+and the library will be persistently set until the next time the build command
+is issued.
+
+To see the currently set library use
+```julia
+using PETSc
+PETSc.libs
+```

--- a/src/PETSc.jl
+++ b/src/PETSc.jl
@@ -2,9 +2,12 @@ module PETSc
 
 using MPI, LinearAlgebra, SparseArrays
 
-using PETSc_jll
+MPI.Initialized() || MPI.Init()
+
+using Libdl
 
 include("const.jl")
+include("startup.jl")
 include("lib.jl")
 include("init.jl")
 include("ref.jl")

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -1,34 +1,12 @@
-
 using Libdl
-const libs = (PETSc_jll.libpetsc, )
 
 function initialize(libhdl::Ptr{Cvoid})
   PetscInitializeNoArguments_ptr = dlsym(libhdl, :PetscInitializeNoArguments)
   @chk ccall(PetscInitializeNoArguments_ptr, PetscErrorCode, ())
 end
 
-
-function DataTypeFromString(libhdl::Ptr{Cvoid}, name::AbstractString)
-    PetscDataTypeFromString_ptr = dlsym(libhdl, :PetscDataTypeFromString)
-    dtype_ref = Ref{PetscDataType}()
-    found_ref = Ref{PetscBool}()
-    @chk ccall(PetscDataTypeFromString_ptr, PetscErrorCode,
-             (Cstring, Ptr{PetscDataType}, Ptr{PetscBool}),
-             name, dtype_ref, found_ref)
-    @assert found_ref[] == PETSC_TRUE
-    return dtype_ref[]
-end
-function PetscDataTypeGetSize(libhdl::Ptr{Cvoid}, dtype::PetscDataType)
-    PetscDataTypeGetSize_ptr = dlsym(libhdl, :PetscDataTypeGetSize)
-    datasize_ref = Ref{Csize_t}()
-    @chk ccall(PetscDataTypeGetSize_ptr, PetscErrorCode,
-             (PetscDataType, Ptr{Csize_t}), 
-             dtype, datasize_ref)
-    return datasize_ref[]
-end
-
 const libtypes = map(libs) do lib
-    libhdl = dlopen(lib)
+    libhdl = dlopen(lib...)
     initialize(libhdl)
     PETSC_REAL = DataTypeFromString(libhdl, "Real")
     PETSC_SCALAR = DataTypeFromString(libhdl, "Scalar")
@@ -50,10 +28,11 @@ const libtypes = map(libs) do lib
         error("PETSC_INT_SIZE = $PETSC_INT_SIZE not supported.")
 
     # TODO: PetscBLASInt, PetscMPIInt ?
-    return (lib, PetscScalar, PetscReal, PetscInt)
+    return (lib[1], PetscScalar, PetscReal, PetscInt)
 end
 
 const scalar_types = map(x -> x[2], libtypes)
+@assert length(scalar_types) == length(unique(scalar_types))
 
 macro for_libpetsc(expr)
   quote

--- a/src/startup.jl
+++ b/src/startup.jl
@@ -1,0 +1,46 @@
+# Functions needed to find libraries
+function getlibs()
+    libs = ()
+    petsc_libs = ENV["JULIA_PETSC_LIBRARY"]
+
+    flags = Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL
+
+    for petsc_lib in Base.parse_load_path(petsc_libs)
+        libs = (libs..., (petsc_lib, flags))
+    end
+    return libs
+end
+const libs = @static if !haskey(ENV, "JULIA_PETSC_LIBRARY")
+    using PETSc_jll
+    ((PETSc_jll.libpetsc,),)
+else
+    getlibs()
+end
+function DataTypeFromString(libhdl::Ptr{Cvoid}, name::AbstractString)
+    PetscDataTypeFromString_ptr = dlsym(libhdl, :PetscDataTypeFromString)
+    dtype_ref = Ref{PetscDataType}()
+    found_ref = Ref{PetscBool}()
+    @chk ccall(
+        PetscDataTypeFromString_ptr,
+        PetscErrorCode,
+        (Cstring, Ptr{PetscDataType}, Ptr{PetscBool}),
+        name,
+        dtype_ref,
+        found_ref,
+    )
+    @assert found_ref[] == PETSC_TRUE
+    return dtype_ref[]
+end
+function PetscDataTypeGetSize(libhdl::Ptr{Cvoid}, dtype::PetscDataType)
+    PetscDataTypeGetSize_ptr = dlsym(libhdl, :PetscDataTypeGetSize)
+    datasize_ref = Ref{Csize_t}()
+    @chk ccall(
+        PetscDataTypeGetSize_ptr,
+        PetscErrorCode,
+        (PetscDataType, Ptr{Csize_t}),
+        dtype,
+        datasize_ref,
+    )
+    return datasize_ref[]
+end
+


### PR DESCRIPTION
Allow for custom build of PETSc as well as multiple libraries (to allow for single, double, and complex numbers).

This is done with a colon separated environment variable `JULIA_PETSC_LIBRARY` which contains the full path to libraries, for example
```
JULIA_PETSC_LIBRARY=/path/to/double.so:/path/to/single.so
```