### PR TITLE
Update `options.jl` to use `@for_petsc` macro

### DIFF
--- a/examples/SNES_ex2.jl
+++ b/examples/SNES_ex2.jl
@@ -104,8 +104,8 @@ res = PETSc.VecSeq(zeros(size(x)));     # residual vector
 
 S = PETSc.SNES{Float64}(MPI.COMM_SELF; 
         snes_rtol=1e-12, 
-        snes_monitor=true, 
-        snes_converged_reason=true);
+        snes_monitor=nothing,
+        snes_converged_reason=nothing);
 PETSc.setfunction!(S, FormResidual!, res)
 PETSc.setjacobian!(S, FormJacobian!, PJ, PJ)
 

--- a/examples/SNES_ex2b.jl
+++ b/examples/SNES_ex2b.jl
@@ -87,8 +87,8 @@ res = PETSc.VecSeq(zeros(size(x)));     # residual vector
 
 S = PETSc.SNES{Float64}(MPI.COMM_SELF; 
         snes_rtol=1e-12, 
-        snes_monitor=true, 
-        snes_converged_reason=true);
+        snes_monitor=nothing,
+        snes_converged_reason=nothing);
 PETSc.setfunction!(S, FormResidual!, res)
 PETSc.setjacobian!(S, FormJacobian!, PJ, PJ)
 

--- a/examples/laplacian.jl
+++ b/examples/laplacian.jl
@@ -27,8 +27,8 @@ for T in PETSc.scalar_types
 
   ksp = PETSc.KSP(
                   M;
-                  ksp_monitor_true_residual = true,
-                  ksp_view = true,
+                  ksp_monitor_true_residual = nothing,
+                  ksp_view = nothing,
                   ksp_type = "cg",
                   ksp_rtol = 1e-8,
                   pc_type = "gamg",

--- a/src/options.jl
+++ b/src/options.jl
@@ -1,19 +1,75 @@
-
 const CPetscOptions = Ptr{Cvoid}
 
-#TODO: should it be <: AbstractDict{String,String}?
-abstract type AbstractOptions{T}
-end
+"""
+    AbstractOptions{PetscLib <: PetscLibType}
+
+Abstract type of PETSc solver options.
+"""
+abstract type AbstractOptions{PetscLib <: PetscLibType} end
 
 """
-    GlobalOptions{T}()
+    GlobalOptions{PetscLib <: PetscLibType}
 
 The PETSc global options database.
 """
-struct GlobalOptions{T} <: AbstractOptions{T}
-end
+struct GlobalOptions{PetscLib} <: AbstractOptions{PetscLib} end
 Base.cconvert(::Type{CPetscOptions}, obj::GlobalOptions) = C_NULL
 
+"""
+    Options{PetscLib <: PetscLibType}(kw -> arg, ...)
+    Options(petsclib, kw -> arg, ...)
+
+Create a PETSc options data structure for the `petsclib`.
+
+For construction a set of keyword argment pairs should be given. If the option
+has no value it should be set to `nothing` or `true`. Setting an option to
+`false` will cause the option not to be set on the PETSc options table.
+
+# Examples
+```julia-repl
+julia> using PETSc
+
+julia> petsclib = PETSc.petsclibs[1];
+
+julia> PETSc.initialize(petsclib)
+
+julia> opt = PETSc.Options(
+                         petsclib,
+                         ksp_monitor = nothing,
+                         ksp_view = true,
+                         pc_type = "mg",
+                         pc_mg_levels = 1,
+                         false_opt = false,
+                     )
+#PETSc Option Table entries:
+-ksp_monitor
+-ksp_view
+-pc_mg_levels 1
+-pc_type mg
+#End of PETSc Option Table entries
+
+
+julia> opt["ksp_monitor"]
+""
+
+julia> opt["pc_type"]
+"mg"
+
+julia> opt["pc_type"] = "ilu"
+"ilu"
+
+julia> opt["pc_type"]
+"ilu"
+
+julia> opt["false_opt"]
+ERROR: KeyError: key "bad_key" not found
+
+julia> opt["bad_key"]
+ERROR: KeyError: key "bad_key" not found
+```
+
+Manual: [`PetscOptionsCreate`](https://petsc.org/release/docs/manualpages/Sys/PetscOptionsCreate.html)
+"""
 mutable struct Options{T} <: AbstractOptions{T}
     ptr::CPetscOptions
 end
@@ -21,70 +77,121 @@ Base.cconvert(::Type{CPetscOptions}, obj::Options) = obj.ptr
 Base.unsafe_convert(::Type{Ptr{CPetscOptions}}, obj::Options) =
     convert(Ptr{CPetscOptions}, pointer_from_objref(obj))
 
-scalartype(::Options{T}) where {T} = T
-
-@for_libpetsc begin
-    function Options{$PetscScalar}()
-        @assert initialized($petsclib)
-        opts = Options{$PetscScalar}(C_NULL)
-        @chk ccall((:PetscOptionsCreate, $libpetsc), PetscErrorCode, (Ptr{CPetscOptions},), opts)
-        finalizer(destroy, opts)
-        return opts
-    end
-    function destroy(opts::Options{$PetscScalar})
-        finalized($petsclib) ||
-        @chk ccall((:PetscOptionsDestroy, $libpetsc), PetscErrorCode, (Ptr{CPetscOptions},), opts)
-        return nothing
-    end
-
-    function Base.push!(::GlobalOptions{$PetscScalar}, opts::Options{$PetscScalar})
-        @chk ccall((:PetscOptionsPush, $libpetsc), PetscErrorCode, (CPetscOptions,), opts)
-        return nothing
-    end
-    function Base.pop!(::GlobalOptions{$PetscScalar})
-        @chk ccall((:PetscOptionsPop, $libpetsc), PetscErrorCode, ())
-        return nothing
-    end
-    function Base.setindex!(opts::AbstractOptions{$PetscScalar}, val, key)
-        @chk ccall((:PetscOptionsSetValue, $libpetsc), PetscErrorCode,
-            (CPetscOptions, Cstring, Cstring),
-            opts, string('-',key), (val === true || isnothing(val)) ? C_NULL : string(val))
-    end
-
-    function view(opts::AbstractOptions{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib))
-        @chk ccall((:PetscOptionsView, $libpetsc), PetscErrorCode,
-                  (CPetscOptions, CPetscViewer),
-                  opts, viewer);
-        return nothing
-    end
-end
-
-"""
-    Options{T}(kw => arg, ...)
-
-Create a new PETSc options database.
-"""
-function Options{T}(ps::Pair...) where {T}
-    opts = Options{T}()
-    for (k,v) in ps
+Options(petsclib; kwargs...) = Options(petsclib, kwargs...)
+function Options(petsclib, ps::Pair...)
+    opts = Options(petsclib)
+    for (k, v) in ps
         opts[k] = v
     end
     return opts
 end
+
+@for_petsc function Options(::$UnionPetscLib)
+    opts = Options{$PetscLib}(C_NULL)
+    @assert initialized($PetscLib)
+    @chk ccall(
+        (:PetscOptionsCreate, $petsc_library),
+        PetscErrorCode,
+        (Ptr{CPetscOptions},),
+        opts,
+    )
+    finalizer(finalize, opts)
+    return opts
+end
+
+@for_petsc function finalize(opts::Options{$PetscLib})
+    finalized($PetscLib) || @chk ccall(
+        (:PetscOptionsDestroy, $petsc_library),
+        PetscErrorCode,
+        (Ptr{CPetscOptions},),
+        opts,
+    )
+    return nothing
+end
+
+@for_petsc function Base.push!(
+    ::GlobalOptions{$PetscLib},
+    opts::Options{$PetscLib},
+)
+    @chk ccall(
+        (:PetscOptionsPush, $petsc_library),
+        PetscErrorCode,
+        (CPetscOptions,),
+        opts,
+    )
+    return nothing
+end
+
+@for_petsc function Base.pop!(::GlobalOptions{$PetscLib})
+    @chk ccall((:PetscOptionsPop, $petsc_library), PetscErrorCode, ())
+    return nothing
+end
+
+@for_petsc function Base.setindex!(opts::AbstractOptions{$PetscLib}, val, key)
+    val === true && (val = nothing)
+    val === false && (return val)
+
+    @chk ccall(
+        (:PetscOptionsSetValue, $petsc_library),
+        PetscErrorCode,
+        (CPetscOptions, Cstring, Cstring),
+        opts,
+        string('-', key),
+        isnothing(val) ? C_NULL : string(val),
+    )
+
+    return val
+end
+
+@for_petsc function Base.getindex(opts::AbstractOptions{$PetscLib}, key)
+    val = Vector{UInt8}(undef, 256)
+    set_ref = Ref{PetscBool}()
+    @chk ccall(
+        (:PetscOptionsGetString, $petsc_library),
+        PetscErrorCode,
+        (CPetscOptions, Cstring, Cstring, Ptr{UInt8}, Csize_t, Ptr{PetscBool}),
+        opts,
+        C_NULL,
+        string('-', key),
+        val,
+        sizeof(val),
+        set_ref,
+    )
+    val = GC.@preserve val unsafe_string(pointer(val))
+    set_ref[] == PETSC_TRUE || throw(KeyError(key))
+    return val
+end
+
+@for_petsc function view(
+    opts::AbstractOptions{$PetscLib},
+    viewer::AbstractViewer{$PetscLib} = ViewerStdout($PetscLib, MPI.COMM_SELF),
+)
+    @chk ccall(
+        (:PetscOptionsView, $petsc_library),
+        PetscErrorCode,
+        (CPetscOptions, CPetscViewer),
+        opts,
+        viewer,
+    )
+    return nothing
+end
+
+@for_petsc GlobalOptions(::$UnionPetscLib) = GlobalOptions{$PetscLib}()
 
 Base.show(io::IO, opts::AbstractOptions) = _show(io, opts)
 
 """
     with(f, opts::Options)
 
-Call `f()` with the [`Options`](@ref) `opts` set temporarily (in addition to any global options).
+Call `f()` with the [`Options`](@ref) `opts` set temporarily (in addition to any
+global options).
 """
 function with(f, opts::Options{T}) where {T}
-  global_opts = GlobalOptions{T}()
-  push!(global_opts, opts)
-  try
-    f()
-  finally
-    pop!(global_opts)
-  end
+    global_opts = GlobalOptions{T}()
+    push!(global_opts, opts)
+    try
+        f()
+    finally
+        pop!(global_opts)
+    end
 end

--- a/src/options.jl
+++ b/src/options.jl
@@ -195,3 +195,29 @@ function with(f, opts::Options{T}) where {T}
         pop!(global_opts)
     end
 end
+
+"""
+    parse_options(args::Vector{String})
+
+Parse the `args` vector into a `NamedTuple` that can be used as the options for
+the PETSc solvers.
+
+```sh
+julia --project file.jl -ksp_monitor -pc_type mg -ksp_view
+```
+"""
+function parse_options(args::Vector{String})
+    i = 1
+    opts = Dict{Symbol, Union{String, Nothing}}()
+    while i <= length(args)
+        @assert args[i][1] == '-' && length(args[i]) > 1
+        if i == length(args) || args[i + 1][1] == '-'
+            opts[Symbol(args[i][2:end])] = nothing
+            i = i + 1
+        else
+            opts[Symbol(args[i][2:end])] = args[i + 1]
+            i = i + 2
+        end
+    end
+    return NamedTuple(opts)
+end

--- a/src/snes.jl
+++ b/src/snes.jl
@@ -3,10 +3,10 @@ const CSNES = Ptr{Cvoid}
 const CSNESType = Cstring
 
 
-mutable struct SNES{T}
+mutable struct SNES{T, PetscLib}
     ptr::CSNES
     comm::MPI.Comm
-    opts::Options{T}
+    opts::Options{PetscLib}
     fn!
     fn_vec
     update_jac!
@@ -50,8 +50,8 @@ end
 
     function SNES{$PetscScalar}(comm::MPI.Comm; kwargs...)
         @assert initialized($petsclib)
-        opts = Options{$PetscScalar}(kwargs...)
-        snes = SNES{$PetscScalar}(C_NULL, comm, opts, nothing, nothing, nothing, nothing, nothing)
+        opts = Options($petsclib, kwargs...)
+        snes = SNES{$PetscScalar, $PetscLib}(C_NULL, comm, opts, nothing, nothing, nothing, nothing, nothing)
         @chk ccall((:SNESCreate, $libpetsc), PetscErrorCode, (MPI.MPI_Comm, Ptr{CSNES}), comm, snes)
 
         with(snes.opts) do

--- a/test/options.jl
+++ b/test/options.jl
@@ -1,0 +1,85 @@
+using Test
+using PETSc
+
+@testset "options tests" begin
+    kw_opts = (
+        ksp_monitor = nothing,
+        ksp_view = true,
+        false_opt = false,
+        da_grid_x = 100,
+        da_grid_y = 100,
+        pc_type = "mg",
+        pc_mg_levels = 1,
+        mg_levels_0_pc_type = "ilu",
+    )
+    for petsclib in PETSc.petsclibs
+        PETSc.initialize(petsclib)
+
+        opts = PETSc.Options(petsclib; kw_opts...)
+
+        # Check that all the keys got added
+        for (key, val) in pairs(kw_opts)
+            key = string(key)
+            if val === false
+                @test_throws KeyError opts[key]
+            else
+                val = isnothing(val) || val === true ? "" : string(val)
+                @test val == opts[key]
+            end
+        end
+
+        # Check that we throw when a bad key is asked for
+        @test_throws KeyError opts["bad key"]
+
+        # try to insert some new keys
+        opts["new_opt"] = 1
+        opts["nothing_opt"] = nothing
+        @test "" == opts["nothing_opt"]
+        @test "1" == opts["new_opt"]
+
+        # Check that viewer is working
+        _stdout = stdout
+        (rd, wr) = redirect_stdout()
+        @show opts
+
+        @test readline(rd) == "opts = #PETSc Option Table entries:"
+        @test readline(rd) == "-da_grid_x 100"
+        @test readline(rd) == "-da_grid_y 100"
+        @test readline(rd) == "-ksp_monitor"
+        @test readline(rd) == "-ksp_view"
+        @test readline(rd) == "-mg_levels_0_pc_type ilu"
+        @test readline(rd) == "-new_opt 1"
+        @test readline(rd) == "-nothing_opt"
+        @test readline(rd) == "-pc_mg_levels 1"
+        @test readline(rd) == "-pc_type mg"
+        @test readline(rd) == "#End of PETSc Option Table entries"
+        @test readline(rd) == ""
+
+        glo_opts = PETSc.GlobalOptions(petsclib)
+        show(stdout, "text/plain", glo_opts)
+        @test readline(rd) == "#No PETSc Option Table entries"
+
+        # Try to set some options and check that they are set
+        PETSc.with(opts) do
+            show(stdout, "text/plain", glo_opts)
+        end
+        @test readline(rd) == "#PETSc Option Table entries:"
+        @test readline(rd) == "-da_grid_x 100"
+        @test readline(rd) == "-da_grid_y 100"
+        @test readline(rd) == "-ksp_monitor"
+        @test readline(rd) == "-ksp_view"
+        @test readline(rd) == "-mg_levels_0_pc_type ilu"
+        @test readline(rd) == "-new_opt 1"
+        @test readline(rd) == "-nothing_opt"
+        @test readline(rd) == "-pc_mg_levels 1"
+        @test readline(rd) == "-pc_type mg"
+        @test readline(rd) == "#End of PETSc Option Table entries"
+
+        show(stdout, "text/plain", glo_opts)
+        @test readline(rd) == "#No PETSc Option Table entries"
+
+        redirect_stdout(_stdout)
+
+        PETSc.finalize(petsclib)
+    end
+end

--- a/test/options.jl
+++ b/test/options.jl
@@ -83,3 +83,24 @@ using PETSc
         PETSc.finalize(petsclib)
     end
 end
+
+@testset "parse_options tests" begin
+    @test begin
+        run(`julia --project -e "using PETSc
+                                 using Test
+                                 opts = PETSc.parse_options(ARGS)
+                                 @test length(opts) == 4
+                                 @test opts.ksp_monitor === nothing
+                                 @test opts.ksp_view === nothing
+                                 @test opts.pc_type === \"mg\"
+                                 @test opts.da_grid_x === \"100\"
+                                 @test_throws ErrorException opts.bad_opt
+                                 "
+                                 --
+                                 -ksp_monitor
+                                 -da_grid_x 100
+                                 -ksp_view
+                                 -pc_type mg`)
+        true
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ PETSc.initialize()
   w = M*x
   @test w ≈ S*x
 
-  ksp = PETSc.KSP(M; ksp_rtol=1e-8, pc_type="jacobi", ksp_monitor=true)
+  ksp = PETSc.KSP(M; ksp_rtol=1e-8, pc_type="jacobi", ksp_monitor=nothing)
   #PETSc.settolerances!(ksp; rtol=1e-8)
 
   @test PETSc.gettype(ksp) == "gmres" # default

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+include("options.jl")
+
 using Test
 using PETSc, MPI, LinearAlgebra, SparseArrays
 PETSc.initialize()


### PR DESCRIPTION
Couple changes that happen with this PR

- For PETSc arguments that have no input, `nothing` not `true` should be used, e.g., `ksp_view = nothing`.
- Add `parse_options` for parsing command line arguments