### PR TITLE
Use petsc function to get mpi communicator

### DIFF
--- a/src/PETSc.jl
+++ b/src/PETSc.jl
@@ -19,5 +19,6 @@ include("matshell.jl")
 include("ksp.jl")
 include("pc.jl")
 include("snes.jl")
+include("sys.jl")
 
 end

--- a/src/mat.jl
+++ b/src/mat.jl
@@ -22,7 +22,7 @@ Memory allocation is handled by PETSc.
 """
 mutable struct MatSeqAIJ{T} <: AbstractMat{T}
     ptr::CMat
-    comm::MPI.Comm
+    __comm__::MPI.Comm # Do not access directly use `getcomm(mat)`
 end
 
 """
@@ -32,7 +32,7 @@ PETSc dense array. This wraps a Julia `Matrix{T}` object.
 """
 mutable struct MatSeqDense{T} <: AbstractMat{T}
     ptr::CMat
-    comm::MPI.Comm
+    __comm__::MPI.Comm # Do not access directly use `getcomm(mat)`
     array::Matrix{T}
 end
 
@@ -92,7 +92,7 @@ end
         @chk ccall((:MatAssemblyEnd, $libpetsc), PetscErrorCode, (CMat, MatAssemblyType), M, t)
         return nothing
     end
-    function view(mat::AbstractMat{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, mat.comm))
+    function view(mat::AbstractMat{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, getcomm(mat)))
         @chk ccall((:MatView, $libpetsc), PetscErrorCode, 
                     (CMat, CPetscViewer),
                 mat, viewer);

--- a/src/matshell.jl
+++ b/src/matshell.jl
@@ -9,7 +9,7 @@ This can be changed by defining `PETSc._mul!`.
 """
 mutable struct MatShell{T,A} <: AbstractMat{T}
     ptr::CMat
-    comm::MPI.Comm
+    __comm__::MPI.Comm # Do not access directly use `getcomm(matshell)`
     obj::A
 end
 

--- a/src/pc.jl
+++ b/src/pc.jl
@@ -5,7 +5,7 @@ const CPCType = Cstring
 
 mutable struct PC{T}
     ptr::Ptr{Cvoid}
-    comm::MPI.Comm
+    __comm__::MPI.Comm # Do not access directly use `getcomm(pc)`
 end
 
 Base.cconvert(::Type{CPC}, obj::PC) = obj.ptr
@@ -24,7 +24,7 @@ scalartype(::PC{T}) where {T} = T
     end
 
     function PC(ksp::KSP{$PetscScalar})
-        pc = PC{$PetscScalar}(C_NULL, ksp.comm)
+        pc = PC{$PetscScalar}(C_NULL, getcomm(ksp))
         @chk ccall((:KSPGetPC, $libpetsc), PetscErrorCode, (CKSP, Ptr{CPC}), ksp, pc)
         incref(pc) # need to manually increment the reference counter
         finalizer(destroy, pc)
@@ -53,7 +53,7 @@ scalartype(::PC{T}) where {T} = T
         return unsafe_string(t_r[])
     end
 
-    function view(pc::PC{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, pc.comm))
+    function view(pc::PC{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, getcomm(pc)))
         @chk ccall((:PCView, $libpetsc), PetscErrorCode,
                     (CPC, CPetscViewer),
                 pc, viewer);

--- a/src/snes.jl
+++ b/src/snes.jl
@@ -5,7 +5,7 @@ const CSNESType = Cstring
 
 mutable struct SNES{T, PetscLib}
     ptr::CSNES
-    comm::MPI.Comm
+    __comm__::MPI.Comm # Do not access directly use `getcomm(snes)`
     opts::Options{PetscLib}
     fn!
     fn_vec
@@ -104,7 +104,7 @@ end
         return unsafe_string(t_r[])
     end
 
-    function view(snes::SNES{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, snes.comm))
+    function view(snes::SNES{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, getcomm(snes)))
         @chk ccall((:SNESView, $libpetsc), PetscErrorCode,
                     (CSNES, CPetscViewer),
                 snes, viewer);

--- a/src/sys.jl
+++ b/src/sys.jl
@@ -1,0 +1,21 @@
+const CPetscObject = Ptr{Cvoid}
+
+@for_libpetsc begin
+    function getcomm(
+        obj::Union{
+            AbstractKSP{$PetscScalar},
+            AbstractMat{$PetscScalar},
+            AbstractVec{$PetscScalar},
+        },
+    )
+        comm = MPI.Comm()
+        @chk ccall(
+            (:PetscObjectGetComm, $libpetsc),
+            PetscErrorCode,
+            (CPetscObject, Ptr{MPI.MPI_Comm}),
+            obj,
+            comm,
+        )
+        return comm
+    end
+end

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -28,7 +28,7 @@ https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Vec/VecCreateSeqWit
 """
 mutable struct VecSeq{T} <: AbstractVec{T}
     ptr::CVec
-    comm::MPI.Comm
+    __comm__::MPI.Comm # Do not access directly use `getcomm(vec)`
     array::Vector{T}
 end
 
@@ -83,7 +83,7 @@ Base.parent(v::AbstractVec) = v.array
         r_lo[]:(r_hi[]-$PetscInt(1))
     end
 
-    function view(vec::AbstractVec{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib))
+    function view(vec::AbstractVec{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, getcomm(vec)))
         @chk ccall((:VecView, $libpetsc), PetscErrorCode,
                     (CVec, CPetscViewer),
                 vec, viewer);

--- a/src/viewer.jl
+++ b/src/viewer.jl
@@ -28,7 +28,7 @@ end
 
 @for_petsc function ViewerStdout(
     ::$UnionPetscLib,
-    comm::MPI.Comm = MPI.COMM_SELF,
+    comm::MPI.Comm,
 )
     ptr = ccall(
         (:PETSC_VIEWER_STDOUT_, $petsc_library),


### PR DESCRIPTION
Not all types will have a valid `.comm` member (particularly when hierarchical factorizations are used), so it's better to query petsc for the mpi communicator.