### PR TITLE
Rely on PETSc duplicated comms

### DIFF
--- a/src/PETSc.jl
+++ b/src/PETSc.jl
@@ -31,5 +31,6 @@ include("matshell.jl")
 include("ksp.jl")
 include("pc.jl")
 include("snes.jl")
+include("sys.jl")
 
 end

--- a/src/matshell.jl
+++ b/src/matshell.jl
@@ -9,7 +9,6 @@ This can be changed by defining `PETSc._mul!`.
 """
 mutable struct MatShell{T,A} <: AbstractMat{T}
     ptr::CMat
-    comm::MPI.Comm
     obj::A
 end
 
@@ -30,7 +29,7 @@ MatShell{T}(obj, m, n) where {T} = MatShell{T}(obj, MPI.COMM_SELF, m, n, m, n)
 
 @for_libpetsc begin
     function MatShell{$PetscScalar}(obj::A, comm::MPI.Comm, m, n, M, N) where {A}
-        mat = MatShell{$PetscScalar,A}(C_NULL, comm, obj)
+        mat = MatShell{$PetscScalar,A}(C_NULL, obj)
         # we use the MatShell object itsel
         ctx = pointer_from_objref(mat)
         @chk ccall((:MatCreateShell, $libpetsc), PetscErrorCode,

--- a/src/snes.jl
+++ b/src/snes.jl
@@ -5,7 +5,6 @@ const CSNESType = Cstring
 
 mutable struct SNES{T, PetscLib}
     ptr::CSNES
-    comm::MPI.Comm
     opts::Options{PetscLib}
     fn!
     fn_vec
@@ -51,7 +50,7 @@ end
     function SNES{$PetscScalar}(comm::MPI.Comm; kwargs...)
         @assert initialized($petsclib)
         opts = Options($petsclib, kwargs...)
-        snes = SNES{$PetscScalar, $PetscLib}(C_NULL, comm, opts, nothing, nothing, nothing, nothing, nothing)
+        snes = SNES{$PetscScalar, $PetscLib}(C_NULL, opts, nothing, nothing, nothing, nothing, nothing)
         @chk ccall((:SNESCreate, $libpetsc), PetscErrorCode, (MPI.MPI_Comm, Ptr{CSNES}), comm, snes)
 
         with(snes.opts) do
@@ -104,7 +103,7 @@ end
         return unsafe_string(t_r[])
     end
 
-    function view(snes::SNES{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, snes.comm))
+    function view(snes::SNES{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, getcomm(snes)))
         @chk ccall((:SNESView, $libpetsc), PetscErrorCode,
                     (CSNES, CPetscViewer),
                 snes, viewer);

--- a/src/sys.jl
+++ b/src/sys.jl
@@ -1,0 +1,58 @@
+const CPetscObject = Ptr{Cvoid}
+
+@for_libpetsc begin
+    function getcomm(
+        obj::Union{
+            AbstractKSP{$PetscScalar},
+            AbstractMat{$PetscScalar},
+            AbstractVec{$PetscScalar},
+        },
+    )
+        comm = MPI.Comm()
+        @chk ccall(
+            (:PetscObjectGetComm, $libpetsc),
+            PetscErrorCode,
+            (CPetscObject, Ptr{MPI.MPI_Comm}),
+            obj,
+            comm,
+        )
+
+        #XXX We should really increase the petsc reference counter.
+        #    But for for some reason the PETSc says that this communicator is
+        #    unknown
+        #=
+        # Call the PetscCommDuplicate to increase reference count
+        @chk ccall(
+            (:PetscCommDuplicate, $libpetsc),
+            PetscErrorCode,
+            (MPI.MPI_Comm, Ptr{MPI.MPI_Comm}, Ptr{Cvoid}),
+            comm,
+            comm,
+            C_NULL,
+        )
+
+        # Register PetscCommDestroy to decriment the reference count
+        finalizer(PetscCommDestroy, comm)
+        =#
+
+        return comm
+    end
+end
+
+#=
+#XXX Not sure why this doesn't work
+@for_libpetsc begin
+    function PetscCommDestroy(
+        comm::MPI.Comm
+    )
+        @show comm.val
+        @chk ccall(
+            (:PetscCommDestroy, $libpetsc),
+            PetscErrorCode,
+            (Ptr{MPI.MPI_Comm},),
+            comm,
+        )
+        return nothing
+    end
+end
+=#

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -29,7 +29,6 @@ $(_doc_external("Vec/VecCreateSeqWithArray"))
 """
 mutable struct VecSeq{T} <: AbstractVec{T}
     ptr::CVec
-    comm::MPI.Comm
     array::Vector{T}
 end
 
@@ -41,7 +40,7 @@ Base.parent(v::AbstractVec) = v.array
 @for_libpetsc begin
     function VecSeq(comm::MPI.Comm, X::Vector{$PetscScalar}; blocksize=1)
         @assert initialized($petsclib)
-        v = VecSeq(C_NULL, comm, X)
+        v = VecSeq(C_NULL, X)
         @chk ccall((:VecCreateSeqWithArray, $libpetsc), PetscErrorCode,
                 (MPI.MPI_Comm, $PetscInt, $PetscInt, Ptr{$PetscScalar}, Ptr{CVec}),
                 comm, blocksize, length(X), X, v)
@@ -84,7 +83,7 @@ Base.parent(v::AbstractVec) = v.array
         r_lo[]:(r_hi[]-$PetscInt(1))
     end
 
-    function view(vec::AbstractVec{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, vec.comm))
+    function view(vec::AbstractVec{$PetscScalar}, viewer::AbstractViewer{$PetscLib}=ViewerStdout($petsclib, getcomm(vec)))
         @chk ccall((:VecView, $libpetsc), PetscErrorCode,
                     (CVec, CPetscViewer),
                 vec, viewer);


### PR DESCRIPTION
Need to sort out why the reference counting isn't working (I cannot call `PetscCommDestroy` on the comm I get back from `PetscCommDuplicate`)