### PR TITLE
Use Base.GC.@preserve on wrapped vectors

### DIFF
--- a/src/ksp.jl
+++ b/src/ksp.jl
@@ -115,7 +115,9 @@ const KSPAT{T, LT} = Union{KSP{T, LT}, Transpose{T, KSP{T, LT}}, Adjoint{T, KSP{
 
 LinearAlgebra.ldiv!(x::AbstractVec{T}, ksp::KSPAT{T, LT}, b::AbstractVec{T}) where {T, LT} = solve!(x, ksp, b)
 function LinearAlgebra.ldiv!(x::AbstractVector{T}, ksp::KSPAT{T, LT}, b::AbstractVector{T}) where {T, LT}
-    parent(solve!(AbstractVec(x), ksp, AbstractVec(b)))
+    b_ = AbstractVec(b)
+    x_ = AbstractVec(x)
+    Base.GC.@preserve x_ b_ parent(solve!(x_, ksp, b_))
 end
 Base.:\(ksp::KSPAT{T, LT}, b::AbstractVector{T}) where {T, LT} = ldiv!(similar(b), ksp, b)
 

--- a/src/mat.jl
+++ b/src/mat.jl
@@ -194,5 +194,8 @@ AbstractMat(A::SparseMatrixCSC) = MatSeqAIJ(A)
 
 const MatAT{T} = Union{AbstractMat{T}, Transpose{T, <:AbstractMat{T}}, Adjoint{T, <:AbstractMat{T}}}
 
-LinearAlgebra.mul!(y::AbstractVector{T}, M::MatAT{T}, x::AbstractVector{T}) where {T} =
-    parent(LinearAlgebra.mul!(AbstractVec(y), M, AbstractVec(x)))
+function LinearAlgebra.mul!(y::AbstractVector{T}, M::MatAT{T}, x::AbstractVector{T}) where {T}
+    y_ = AbstractVec(y)
+    x_ = AbstractVec(x)
+    Base.GC.@preserve y_ x_ parent(LinearAlgebra.mul!(y_, M, x_))
+end

--- a/src/snes.jl
+++ b/src/snes.jl
@@ -156,4 +156,7 @@ end
 
 end
 
-solve!(x::AbstractVector{T}, snes::SNES{T}) where {T} = parent(solve!(AbstractVec(x), snes))
+function solve!(x::AbstractVector{T}, snes::SNES{T}) where {T}
+    x_ = AbstractVec(x)
+    Base.GC.@preserve x_ parent(solve!(x_, snes))
+end


### PR DESCRIPTION
I am not sure why this is needed, but I was getting periodic failures with the GC freeing julia vectors that were automatically wrapped.

On https://github.com/JuliaParallel/PETSc.jl/commit/827e7e195910a04712e8f793fddb718fb4582dd2 this would fail occasionally:
```julia-repl
julia> include("try.jl")^C

julia>
julia> for k = 1:100
           @show k
           include("try.jl")
       end
k = 1
[ Info: Precompiling PETSc [ace2c81b-2b5f-4b1e-a30d-d662738edfe0]
k = 2
k = 3
[0]PETSC ERROR: --------------------- Error Message --------------------------------------------------------------
[0]PETSC ERROR: Corrupt argument: https://www.mcs.anl.gov/petsc/documentation/faq.html#valgrind
[0]PETSC ERROR: Object already free: Parameter # 1
.....
```

where `try.jl` is
```julia
using PETSc
PETSc.initialize()
f!(y,x) = y .= 2 .*x
M = PETSc.MatShell{Float64}(f!,10,10)
x = rand(10)
y = M * x
```

But with the PR it does not fail. So it seems that the garbage collector sometimes cleans up the wrapped object prematurely.