### PR TITLE
Fix hang on view with MPI

### DIFF
--- a/src/viewer.jl
+++ b/src/viewer.jl
@@ -20,7 +20,6 @@ $(_doc_external("Viewer/PETSC_VIEWER_STDOUT_"))
 """
 mutable struct ViewerStdout{PetscLib} <: AbstractViewer{PetscLib}
     ptr::CPetscViewer
-    comm::MPI.Comm
 end
 
 @for_petsc function ViewerStdout(
@@ -33,7 +32,7 @@ end
         (MPI.MPI_Comm,),
         comm,
     )
-    return ViewerStdout{$PetscLib}(ptr, comm)
+    return ViewerStdout{$PetscLib}(ptr)
 end
 
 @for_petsc function Base.push!(
@@ -77,9 +76,15 @@ function _show(io::IO, obj)
     try
         rd, = redirect_stdout()
         view(obj)
+
+        # Since not all MPI ranks are guaranteed to print we put in a newline
+        # that we remove with the write since readavailable will hang if there
+        # is no data in the stream
+        println()
+
         Libc.flush_cstdio()
         flush(stdout)
-        write(io, readavailable(rd))
+        write(io, readavailable(rd)[1:end-1])
     finally
         redirect_stdout(old_stdout)
     end


### PR DESCRIPTION
@simonbyrne Do you have thoughts on this? When using the PETSc viewer with MPI not all ranks will necessarily write to stdout so its possible for `readavailable` to hang.