### PR TITLE
Add Windows CI again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
+          - windows-latest
         arch:
           - x64
     steps:


### PR DESCRIPTION
This was failing with the old jlls (https://github.com/JuliaPackaging/Yggdrasil/issues/1611), worth seeing if the new ones fix things.