### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ The installation can be tested with
 
 By default, the package uses a pre-built binary of
 [`PETSc`](https://github.com/JuliaBinaryWrappers/PETSc_jll.jl) along with a
-default installation of `MPI.jl`. Note that the distributed version of PETSc is using real,
-`Float64` numbers; build details can be found
-[here](https://github.com/JuliaPackaging/Yggdrasil/blob/master/P/PETSc/build_tarballs.jl)
+default installation of `MPI.jl`.
 
 ## System Builds
 


### PR DESCRIPTION
@boriskaus Lookin at BinaryBuilder, I believe we now distribute all the versions - not just Float64_Real_Int32.

Please merge if it is ok to remove this line in the README - or update it to reflect the current status.