### PR TITLE
Update ci.yml for Mac aarch64 and use Julia-actions/cache to improve caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
-      - uses: julia-actions/cache@latest
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 'lts'
           - '1'
         os:
           - macOS-13        # with intel processors 
@@ -33,7 +32,10 @@ jobs:
           - os: macOS-latest
             arch: aarch64
             version: 1
-          
+          - os: ubuntu-latest
+            arch: x64
+            version: 'lts'
+            
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,17 @@ jobs:
       matrix:
         version:
           - 'lts'
-          - '1.11'
+          - '1'
         os:
-          - macOS-latest
           - macOS-13        # with intel processors 
           - ubuntu-latest
         arch:
           - x64 
+        include:
+          - os: macOS-latest
+            arch: aarch64
+            version: 1
+          
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,8 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'     
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
+      - uses: julia-actions/cache@latest
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         


### PR DESCRIPTION
`macOS-latest` is now aarch64 - so separate out that build recipe in an include to make sure it picks the right architecture. Otherwise, it is just testing x64 in emulation on ARM.

macOS-13 is x64 (but I am not sure if it is native or not). We could probably drop that too, since Apple stopped shipping those a few years ago - but people do still have them.

Also changing the version to test with `1` which tests with the latest stable release. Running `lts` only on linux should suffice to ensure we don't accidentally break it. This will all reduce CI load while the package is under heavy development.