### PR TITLE
Update to PETSc 3.22

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 [compat]
 MPI = "0.20"
 MPIPreferences = "0.1"
-PETSc_jll = "~3.21"
+PETSc_jll = "3.22"
 SparseArrays = "1.10"
 julia = "1.10"
 

--- a/examples/DMSTAG_Stokes_2D.jl
+++ b/examples/DMSTAG_Stokes_2D.jl
@@ -93,7 +93,7 @@ function FormJacobian!(ptr_x_g, J, P, user_ctx)
     # Extract the local vector
     #PETSc.DMGlobalToLocal(user_ctx.dm, cx_g,  PETSc.INSERT_VALUES,  user_ctx.x_l) 
     PETSc.update!(user_ctx.x_l, ptr_x_g, PETSc.INSERT_VALUES)
-    x               =   PETSc.unsafe_localarray(Float64, user_ctx.x_l.ptr;  write=false, read=true);
+    x               =   PETSc.unsafe_localarray(Float64, user_ctx.x_l.ptr;  write=false);
 
     # Check the sparsity pattern
     if isnothing(user_ctx.jac)

--- a/examples/DMSTAG_porwave_1D.jl
+++ b/examples/DMSTAG_porwave_1D.jl
@@ -84,7 +84,7 @@ function FormJacobian!(ptr_x_g, J, P, user_ctx)
 
     # Extract the local vector from pointer to global vector
     PETSc.update!(user_ctx.x_l, ptr_x_g, PETSc.INSERT_VALUES)
-    x               =   PETSc.unsafe_localarray(Float64, user_ctx.x_l.ptr;  write=false, read=true)
+    x               =   PETSc.unsafe_localarray(Float64, user_ctx.x_l.ptr;  write=false)
 
     if isnothing(user_ctx.jac)
         # Compute sparsity pattern of jacobian. This is relatvely slow, but only has to be done once.

--- a/examples/SNES_ex2.jl
+++ b/examples/SNES_ex2.jl
@@ -45,12 +45,12 @@ function FormResidual!(cf,cx, args...)
     if typeof(cx) <: Ptr{Nothing}
         # When this routine is called from PETSc, cx is a pointer to a global vector
         # That's why we have to transfer it first to 
-        x   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cx)
+        x   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cx, write=false)
     else
         x   = cx;
     end
     if typeof(cf) <: Ptr{Nothing}
-        f   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cf)
+        f   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cf, write=true)
     else
         f   = cf;
     end
@@ -76,7 +76,7 @@ end
 function FormJacobian!(cx, args...)
 
     if typeof(cx) <: Ptr{Nothing}
-        x   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cx)
+        x   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cx, write=false)
     else
         x   =   cx;
     end

--- a/examples/SNES_ex2b.jl
+++ b/examples/SNES_ex2b.jl
@@ -35,12 +35,12 @@ function FormResidual!(cf,cx, args...)
     if typeof(cx) <: Ptr{Nothing}
         # When this routine is called from PETSc, cx is a pointer to a global vector
         # That's why we have to transfer it first to 
-        x   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cx)
+        x   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cx, write=false)
     else
         x   = cx;
     end
     if typeof(cf) <: Ptr{Nothing}
-        f   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cf)
+        f   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cf, write=true)
     else
         f   = cf;
     end
@@ -76,7 +76,7 @@ end
 function FormJacobian!(cx, args...)
 
     if typeof(cx) <: Ptr{Nothing}
-        x   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cx)
+        x   =   PETSc.unsafe_localarray(PETSc.scalartype(petsclib),cx, write=false)
     else
         x   =   cx;
     end

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -254,7 +254,7 @@ julia> map_unsafe_localarray(x; write=true) do x
 end
 
 !!! note
-    `Base.finalize` should is automatically called on the array.
+    `Base.finalize` is automatically called on the array.
 """
 function map_unsafe_localarray!(f!, v::AbstractVec{T}; kwargs...) where {T}
     array = unsafe_localarray(T, v.ptr; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,6 @@ if do_mpi
     include("mpi_examples.jl")
 end
 
-
 include("options.jl")
 include("dmda.jl")
 include("old_test.jl")

--- a/test/test_snes.jl
+++ b/test/test_snes.jl
@@ -25,7 +25,7 @@ MPI.Initialized() || MPI.Init()
         # We could do Global->Local here on cfx/cx, provided a pointer to the local
         #  vector is available in user_ctx
         x_in  = PETSc.unsafe_localarray(PetscScalar, cx;  write=false)   # read array
-        fx_in = PETSc.unsafe_localarray(PetscScalar, cfx; read=false)    # write array
+        fx_in = PETSc.unsafe_localarray(PetscScalar, cfx; write=true)    # write array
       
         fx_in[1] = x_in[1]^2       +  x_in[1]*x_in[2] - 3
         fx_in[2] = x_in[1]*x_in[2] +  x_in[2]^2 - 6
@@ -75,7 +75,7 @@ MPI.Initialized() || MPI.Init()
       b  = PETSc.VecSeq(PetscScalar.([0.0, 0.0]));
       PETSc.solve!(x, S, b)
 
-      sol = PETSc.unsafe_localarray(PetscScalar, x.ptr; read=false)
+      sol = PETSc.unsafe_localarray(PetscScalar, x.ptr)
       @test sol ≈ [1.0,2.0] rtol=1e-4
 
       # cleanup


### PR DESCRIPTION
```
➜  test git:(vs/petsc-3.22) julia --project=.. old_test.jl
[0]PETSC ERROR: --------------------- Error Message --------------------------------------------------------------
[0]PETSC ERROR: Object is in wrong state
[0]PETSC ERROR: Vector 'Vec_0x84000000_0' (argument #1) was locked for read-only access in unknown_function() at unknown file:0 (line numbers only accurate to function begin)
[0]PETSC ERROR: See https://petsc.org/release/faq/ for trouble shooting.
[0]PETSC ERROR: Petsc Release Version 3.22.0, Sep 28, 2024 
[0]PETSC ERROR: Unknown Name with 1 MPI process(es) and PETSC_ARCH  on Virals-MacBook-Pro.local by viralshah Fri Oct 18 17:23:46 2024
[0]PETSC ERROR: Configure options: --prefix=/workspace/destdir/lib/petsc/double_real_Int64 --CC=mpicc --FC=mpif90 --CXX=mpicxx --COPTFLAGS=-O3 -g --CXXOPTFLAGS=-O3 -g --FOPTFLAGS=-O3 --with-blaslapack-lib=/workspace/destdir/lib/libopenblas.dylib --with-blaslapack-suffix= --CFLAGS=-fno-stack-protector --FFLAGS=" " --LDFLAGS=-L/workspace/destdir/lib --CC_LINKER_FLAGS= --with-64-bit-indices=1 --with-debugging=0 --with-batch --with-mpi=1 --with-mpi-lib="[/workspace/destdir/lib/libmpifort.dylib,/workspace/destdir/lib/libmpi.dylib]" --with-mpi-include=/workspace/destdir/include --with-sowing=0 --with-precision=double --with-scalar-type=real --with-pthread=0 --PETSC_ARCH=aarch64-apple-darwin20_double_real_Int64 --with-scalapack-lib=/workspace/destdir/lib/libscalapack32.dylib --with-scalapack-include=/workspace/destdir/include --download-suitesparse=1 --download-suitesparse-shared=0 --download-superlu_dist=1 --download-superlu_dist-shared=0 --download-hypre=1 --download-hypre-shared=0 --download-hypre-configure-arguments="--host --build" --download-mumps=1 --download-mumps-shared=0 --download-tetgen=1 --download-triangle=1 --SOSUFFIX=double_real_Int64 --with-shared-libraries=1 --with-clean=1
[0]PETSC ERROR: #1 VecSetErrorIfLocked() at /workspace/srcdir/petsc-3.22.0/include/petscvec.h:649
[0]PETSC ERROR: #2 VecGetArray() at /workspace/srcdir/petsc-3.22.0/src/vec/vec/interface/rvector.c:2020
Tests: Error During Test at /Users/viralshah/.julia/dev/PETSc/test/old_test.jl:96
  Test threw exception
  Expression: ≈(PETSc.solve!([2.0, 3.0], S), [1.0, 2.0], rtol = 0.0001)
  PETSc.PetscError(73)
  Stacktrace:
   [1] unsafe_localarray(::Type{Float64}, cv::Ptr{Nothing}; read::Bool, write::Bool)
     @ PETSc ~/.julia/dev/PETSc/src/vec.jl:144
   [2] unsafe_localarray
     @ ~/.julia/dev/PETSc/src/vec.jl:140 [inlined]
   [3] (::var"#F!#2")(cfx::Ptr{Nothing}, cx::Ptr{Nothing}, a::Nothing)
     @ Main ~/.julia/dev/PETSc/test/old_test.jl:74
   [4] (::PETSc.SNESFn{Float64})(csnes::Ptr{Nothing}, cx::Ptr{Nothing}, cfx::Ptr{Nothing}, ctx::Ptr{Nothing})
     @ PETSc ~/.julia/dev/PETSc/src/snes.jl:94
Test Summary: | Pass  Error  Total  Time
Tests         |   19      1     20  1.5s
ERROR: LoadError: Some tests did not pass: 19 passed, 0 failed, 1 errored, 0 broken.
in expression starting at /Users/viralshah/.julia/dev/PETSc/test/old_test.jl:5
```