### PR TITLE
Instantiate while testing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 PETSc_jll = "8fa3689e-f0b9-5420-9873-adf6ccf46f2d"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PETSc"
 uuid = "ace2c81b-2b5f-4b1e-a30d-d662738edfe0"
 authors = ["Simon Byrne <simonbyrne@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/test/options.jl
+++ b/test/options.jl
@@ -90,6 +90,8 @@ end
         julia = joinpath(Sys.BINDIR, Base.julia_exename())
         run(`$(julia) --startup-file=no --project -e "using PETSc
                                  using Test
+                                 using MPI, Pkg
+                                 Pkg.instantiate()
                                  opts = PETSc.parse_options(ARGS)
                                  @test length(opts) == 4
                                  @test opts.ksp_monitor === nothing

--- a/test/options.jl
+++ b/test/options.jl
@@ -90,7 +90,7 @@ end
         julia = joinpath(Sys.BINDIR, Base.julia_exename())
         run(`$(julia) --startup-file=no --project -e "using PETSc
                                  using Test
-                                 using MPI, Pkg
+                                 using Pkg
                                  Pkg.instantiate()
                                  opts = PETSc.parse_options(ARGS)
                                  @test length(opts) == 4

--- a/test/options.jl
+++ b/test/options.jl
@@ -89,12 +89,11 @@ end
     @test begin
 
         julia = joinpath(Sys.BINDIR, Base.julia_exename())
+        # Force packages to be installed 
         run(`$(julia) --startup-file=no --project -e "using Pkg; Pkg.instantiate()" `)
 
         run(`$(julia) --startup-file=no --project -e "using PETSc
                                  using Test
-                                 using Pkg
-                                 Pkg.instantiate()
                                  opts = PETSc.parse_options(ARGS)
                                  @test length(opts) == 4
                                  @test opts.ksp_monitor === nothing

--- a/test/options.jl
+++ b/test/options.jl
@@ -87,7 +87,10 @@ end
 
 @testset "parse_options tests" begin
     @test begin
+
         julia = joinpath(Sys.BINDIR, Base.julia_exename())
+        run(`$(julia) --startup-file=no --project -e "using Pkg; Pkg.instantiate()" `)
+
         run(`$(julia) --startup-file=no --project -e "using PETSc
                                  using Test
                                  using Pkg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using Test
 using MPI: MPI, mpiexec
-using PETSc, PETSc_jll
+using PETSc, PETSc_jll, Pkg
 
+# Make sure that all dependencies are installed also on a clean system
+Pkg.instantiate()
 
 import MPIPreferences
 @info "Testing PETSc.jl with" MPIPreferences.binary MPIPreferences.abi PETSc_jll.host_platform


### PR DESCRIPTION
This addresses issue #204 by instantiating the environment.
It seems to work on my local tests, but would be good if others can try this as well on a clean machine.