### PR TITLE
Update ex50 to work have MG scaling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PETSc"
 uuid = "ace2c81b-2b5f-4b1e-a30d-d662738edfe0"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Boris Kaus <kaus@uni-mainz.de>", "Viral B. Shah <virals@gmail.com>", "Erik Schnetter <eschnetter@perimeterinstitute.ca>", "Jeremy E. Kozdon <jeremy@kozdon.net>", "Simon Byrne <simonbyrne@gmail.com>"]
 
 [deps]

--- a/examples/ex50.jl
+++ b/examples/ex50.jl
@@ -100,9 +100,12 @@ function solve_poisson(N=100, da_refine=0; solver_opts...)
     da_grid_x = parse(Int, get(opts, Symbol("da_grid_x"), string(N)))
     da_grid_y = parse(Int, get(opts, Symbol("da_grid_y"), string(N)))
 
-    # Use CG solver with LU preconditioner as defaults (robust for MPI tests)
+    # Use CG solver with appropriate preconditioner based on MPI status
     ksp_type = get(opts, Symbol("ksp_type"), "cg")
-    pc_type = get(opts, Symbol("pc_type"), "lu")
+    # Use LU for serial runs, GAMG for parallel MPI runs (more scalable)
+    nprocs = MPI.Comm_size(comm)
+    default_pc = nprocs > 1 ? "gamg" : "lu"
+    pc_type = get(opts, Symbol("pc_type"), default_pc)
     ksp_rtol = parse(Float64, get(opts, Symbol("ksp_rtol"), "1e-12"))
 
     # Set the grid options

--- a/examples/ex50_convergence.jl
+++ b/examples/ex50_convergence.jl
@@ -1,7 +1,7 @@
 # INCLUDE IN MPI TEST
 #
 # This example demonstrates solving a 2D Poisson equation with Neumann boundary
-# conditions using a DMDA and KSP solver.
+# conditions using a DMDA and KSP solver, and performs convergence analysis.
 # 
 # Based on PETSc's ex50.c:
 # https://petsc.org/main/src/ksp/ksp/tutorials/ex50.c.html
@@ -12,11 +12,28 @@
 #
 # ## Usage Examples:
 #
-# 1. Run with default settings (100×100 grid, multigrid):
-#    julia --project=. examples/ex50.jl
+# 1. Run single solve with default settings (100×100 grid, multigrid):
+#    julia --project=. examples/ex50_convergence.jl
 #
 # 2. Set grid size with -N option (creates N×N grid):
-#    julia --project=. examples/ex50.jl -N 50 -ksp_monitor
+#    julia --project=. examples/ex50_convergence.jl -N 50 -ksp_monitor
+#
+# 3. Run convergence analysis with custom resolutions:
+#    julia --project=. examples/ex50_convergence.jl -convergence_analysis -resolutions 9,17,33
+#
+# ## Convergence Test Examples:
+#
+# 1. Direct solver (LU factorization):
+#    julia --project=. examples/ex50_convergence.jl -convergence_analysis -pc_type lu -ksp_type preonly
+#
+# 2. AMG solver (algebraic multigrid):
+#    julia --project=. examples/ex50_convergence.jl -convergence_analysis -pc_type gamg -ksp_type cg
+#
+# 3. Geometric multigrid:
+#    julia --project=. examples/ex50_convergence.jl -convergence_analysis -pc_type mg -ksp_type cg
+#
+# 4. Geometric Galerkin multigrid:
+#    julia --project=. examples/ex50_convergence.jl -convergence_analysis -pc_type mg -pc_mg_galerkin -ksp_type cg
 #
 # 3. Monitor convergence with custom grid:
 #    julia --project=. examples/ex50.jl -da_grid_x 50 -da_grid_y 50 -ksp_monitor
@@ -29,6 +46,9 @@
 #
 # 6. Programmatic usage with custom solver options:
 #    julia -e "include(\"examples/ex50.jl\"); solve_poisson(50, 0; pc_mg_levels=3, ksp_monitor=true)"
+#
+# 7. Run convergence analysis for different resolutions:
+#    julia --project=. examples/ex50.jl -convergence_analysis
 
 using PETSc, MPI, Printf
 
@@ -157,6 +177,9 @@ function solve_poisson(N=100, da_refine=0; solver_opts...)
                 is_boundary = (i == 1 || j == 1 || i == global_size[1] || j == global_size[2])
                 
                 if is_boundary
+                    # NOTE: we use a 1th order accurate stencil at boundaries for Neumann BCs
+                    # This mimics the C-example but limits the overall accuracy of the scheme to first order.
+
                     # Boundary point - variable stencil (only interior neighbors)
                     diag_val = PetscScalar(0)
                     numi = 0  # count of i-direction neighbors
@@ -207,7 +230,6 @@ function solve_poisson(N=100, da_refine=0; solver_opts...)
     # Set the right-hand side
     PETSc.setcomputerhs!(ksp) do b_vec, ksp
         dm = PETSc.getDMDA(ksp)
-        comm = PETSc.getcomm(ksp)
         corners = PETSc.getcorners(dm)
         global_size = PETSc.getinfo(dm).global_size[1:2]
         
@@ -313,9 +335,176 @@ function solve_poisson(N=100, da_refine=0; solver_opts...)
     return solve_time, niter, final_grid_size, sol2D, l2_error
 end
 
+"""
+    convergence_test(; solver_opts...)
+
+Run convergence test for different grid resolutions and compute order of convergence.
+
+# Arguments
+- `solver_opts`: Additional keyword options passed to the PETSc solver.
+
+# Returns
+- `results::Vector{Tuple{Int, Float64, Float64, Float64}}`: Vector of (N, h, l2_error, order) for each resolution.
+"""
+function convergence_test(; solver_opts...)
+    comm = MPI.COMM_WORLD
+    rank = MPI.Comm_rank(comm)
+    
+    # Grid sizes for convergence test
+    Ns = [10, 20, 40, 80, 160]
+    results = []
+    
+    for (i, N) in enumerate(Ns)
+        if rank == 0
+            @printf("Running convergence test for N = %d\n", N)
+        end
+        
+        solve_time, niter, grid_size, sol2D, l2_error = solve_poisson(N, 0; solver_opts...)
+        
+        h = 1.0 / N
+        push!(results, (N, h, l2_error, 0.0))  # order will be computed later
+    end
+    
+    # Compute orders
+    for i in 1:length(results)-1
+        N1, h1, e1, _ = results[i]
+        N2, h2, e2, _ = results[i+1]
+        if e1 > 0 && e2 > 0
+            order = log(e1 / e2) / log(h1 / h2)
+            results[i] = (N1, h1, e1, order)
+        end
+    end
+    results[end] = (results[end][1], results[end][2], results[end][3], NaN)  # last one has no order
+    
+    # Print table
+    if rank == 0
+        @printf("\nConvergence Test Results:\n")
+        @printf("%-5s %-10s %-12s %-8s\n", "N", "h", "L2 Error", "Order")
+        @printf("%-5s %-10s %-12s %-8s\n", "-"^5, "-"^10, "-"^12, "-"^8)
+        for (N, h, err, order) in results
+            if isnan(order)
+                @printf("%-5d %-10.6f %-12.6e %-8s\n", N, h, err, "N/A")
+            else
+                @printf("%-5d %-10.6f %-12.6e %-8.2f\n", N, h, err, order)
+            end
+        end
+    end
+    
+    return results
+end
+
+"""
+    convergence_analysis(resolutions=[10, 20, 40, 80, 160], base_mg_levels=1; solver_opts...)
+
+Run a convergence analysis by solving the Poisson equation on different grid resolutions
+and computing the order of convergence.
+
+# Arguments
+- `resolutions::Vector{Int}`: List of grid sizes (N×N) to test. Default is [10, 20, 40, 80, 160].
+- `base_mg_levels::Int`: Number of MG levels at the coarsest grid. Default is 1.
+- `solver_opts`: Additional keyword options passed to the PETSc solver.
+
+# Returns
+- `results::Vector{Tuple{Int, Float64, Float64, Float64, Float64, String, Float64, Int}}`: Vector of (N, h, l2_error, order, solve_time, levels_str, time_order, niter) for each resolution.
+"""
+function convergence_analysis(resolutions=[10, 20, 40, 80, 160], base_mg_levels=1; solver_opts...)
+    comm = MPI.COMM_WORLD
+    rank = MPI.Comm_rank(comm)
+    
+    min_N = minimum(resolutions)
+    pc_type = get(solver_opts, :pc_type, "gamg")
+    ksp_type = get(solver_opts, :ksp_type, "cg")
+    results = []
+    
+    for (i, N) in enumerate(resolutions)
+        # Compute MG levels: base + floor(log2(N / min_N))
+        levels = base_mg_levels + floor(Int, log2(N / min_N))
+        levels = min(levels, 3)  # Limit to 3 to avoid ratio issues for large N
+        levels_str = if pc_type in ["mg", "gamg"] string(levels) else "--" end
+        opts_dict = Dict(solver_opts)
+        if pc_type in ["mg"]
+            opts_dict[:pc_mg_levels] = string(levels)
+        end
+        
+        if rank == 0
+            @printf("Running convergence analysis for N = %d (MG levels = %s)\n", N, levels_str)
+        end
+        
+        # Run twice for the first grid to exclude compilation time
+        if i == 1
+            solve_poisson(N, 0; opts_dict...)  # discard first run
+        end
+        solve_time, niter, grid_size, sol2D, l2_error = solve_poisson(N, 0; opts_dict...)
+        
+        h = 1.0 / N
+        push!(results, (N, levels_str, h, niter, l2_error, 0.0, solve_time, 0.0))  # order and time_order will be computed later
+    end
+    
+    # Compute orders
+    for i in 1:length(results)-1
+        N1, levels_str1, h1, niter1, e1, _, t1, _ = results[i]
+        N2, levels_str2, h2, niter2, e2, _, t2, _ = results[i+1]
+        if e1 > 0 && e2 > 0 && h1 > 0 && h2 > 0
+            order = log(e1 / e2) / log(h1 / h2)
+        else
+            order = NaN
+        end
+        if t1 > 0 && t2 > 0 && N1 > 0 && N2 > 0
+            time_order = log(t2 / t1) / (2 * log(N2 / N1))  # Divide by 2 for 2D scaling
+        else
+            time_order = NaN
+        end
+        results[i] = (N1, levels_str1, h1, niter1, e1, order, t1, time_order)
+    end
+    if length(results) > 0
+        results[end] = (results[end][1], results[end][2], results[end][3], results[end][4], results[end][5], NaN, results[end][7], NaN)  # last ones have no order
+    end
+    
+    # Print table
+    if rank == 0
+        @printf("\nConvergence Analysis Results (KSP: %s, PC: %s):\n", ksp_type, pc_type)
+        @printf("%-5s %-8s %-10s %-10s %-12s %-8s %-10s %-8s\n", "N", "MG Lvl", "h", "KSP Iters", "L2 Error", "𝒪(N)", "Time (s)", "𝒪(Time)")
+        @printf("%-5s %-8s %-10s %-10s %-12s %-8s %-10s %-8s\n", "-"^5, "-"^8, "-"^10, "-"^10, "-"^12, "-"^8, "-"^10, "-"^8)
+        for (N, levels_str, h, niter, err, order, time, time_order) in results
+            if isnan(order) && isnan(time_order)
+                @printf("%-5d %-8s %-10.6f %-10d %-12.6e %-8s %-10.4f %-8s\n", N, levels_str, h, niter, err, "N/A", time, "N/A")
+            elseif isnan(order)
+                @printf("%-5d %-8s %-10.6f %-10d %-12.6e %-8s %-10.4f %-8.2f\n", N, levels_str, h, niter, err, "N/A", time, time_order)
+            elseif isnan(time_order)
+                @printf("%-5d %-8s %-10.6f %-10d %-12.6e %-8.2f %-10.4f %-8s\n", N, levels_str, h, niter, err, order, time, "N/A")
+            else
+                @printf("%-5d %-8s %-10.6f %-10d %-12.6e %-8.2f %-10.4f %-8.2f\n", N, levels_str, h, niter, err, order, time, time_order)
+            end
+        end
+    end
+    
+    return results
+end
+
 # If run as script, call the function with defaults
 if !isinteractive() && abspath(PROGRAM_FILE) == @__FILE__
-    solve_poisson()
+    if "-convergence_analysis" in ARGS
+        # Remove the flag from ARGS
+        args = filter(x -> x != "-convergence_analysis", ARGS)
+        opts = PETSc.parse_options(args)
+        
+        # Parse resolutions from -resolutions option
+        resolutions_str = get(opts, Symbol("resolutions"), "10,20,40,80,160")
+        resolutions = parse.(Int, split(resolutions_str, ","))
+        
+        # Parse base_mg_levels from -base_mg_levels option
+        base_mg_levels_str = get(opts, Symbol("base_mg_levels"), "1")
+        base_mg_levels = parse(Int, base_mg_levels_str)
+        
+        convergence_analysis(resolutions, base_mg_levels; opts...)
+    elseif "-convergence_test" in ARGS
+        # Remove the flag from ARGS
+        args = filter(x -> x != "-convergence_test", ARGS)
+        opts = PETSc.parse_options(args)
+        convergence_test(; opts...)
+    else
+        solve_poisson()
+    end
 else
     solve_time, niter, final_grid_size, sol2D, l2_error = solve_poisson();
 end

--- a/examples/ex50_convergence.jl
+++ b/examples/ex50_convergence.jl
@@ -1,5 +1,3 @@
-# INCLUDE IN MPI TEST
-#
 # This example demonstrates solving a 2D Poisson equation with Neumann boundary
 # conditions using a DMDA and KSP solver, and performs convergence analysis.
 # 
@@ -288,8 +286,13 @@ function solve_poisson(N=100, da_refine=0; solver_opts...)
     h = PetscScalar(1) ./ global_size
 
     sol = PETSc.get_solution(ksp)
-    sol2D = copy(sol[:])
-    sol2D = reshape(sol2D, Int64(corners.size[1]), Int64(corners.size[2]))
+    
+    # Get local solution array for analysis
+    sol2D = nothing
+    PETSc.withlocalarray!(sol; read=true) do s
+        sol2D = copy(s)
+        sol2D = reshape(sol2D, Int64(corners.size[1]), Int64(corners.size[2]))
+    end
     
     l2_error = 0.0
     PETSc.withlocalarray!(sol; read=true) do s

--- a/examples/ex50_convergence.jl
+++ b/examples/ex50_convergence.jl
@@ -427,11 +427,8 @@ function convergence_analysis(resolutions=[10, 20, 40, 80, 160], base_mg_levels=
     results = []
     
     for (i, N) in enumerate(resolutions)
-        # Compute MG levels: use enough levels to reach a small coarse grid
-        # For N x N grid, we can have floor(log2(N/8)) levels to reach ~8x8 coarse grid
-        max_levels = floor(Int, log2(N / 8))
-        levels = min(max_levels, mg_levels_cap)  # Cap at mg_levels_cap levels
-        levels = max(levels, 2)      # Minimum 2 levels
+        # Compute MG levels: start with base_mg_levels for first resolution, increase by 1 for each subsequent
+        levels = base_mg_levels + (i - 1)
         levels_str = if pc_type in ["mg", "gamg"] string(levels) else "--" end
         opts_dict = Dict(solver_opts)
         if pc_type == "mg"

--- a/src/autowrapped/Mataddons_wrappers.jl
+++ b/src/autowrapped/Mataddons_wrappers.jl
@@ -2897,7 +2897,7 @@ function MatNullSpaceDestroy(petsclib::PetscLibType, sp::MatNullSpace) end
                (:MatNullSpaceDestroy, $petsc_library),
                PetscErrorCode,
                (Ptr{MatNullSpace},),
-               sp,
+               Ref(sp),
               )
 
 

--- a/test/mat.jl
+++ b/test/mat.jl
@@ -290,11 +290,14 @@ end
         x = PetscScalar.(collect(1:4))
         y_expected = Ajl * x
         
-        vec_x = LibPETSc.VecCreateSeqWithArray(petsclib, LibPETSc.PETSC_COMM_SELF, PetscInt(1), PetscInt(length(x)), copy(x))
+        xc = copy(x)
+        vec_x = LibPETSc.VecCreateSeqWithArray(petsclib, LibPETSc.PETSC_COMM_SELF, PetscInt(1), PetscInt(length(x)), xc)
         vec_y = LibPETSc.VecCreateSeq(petsclib, LibPETSc.PETSC_COMM_SELF, PetscInt(3))
         
         mul!(vec_y, A, vec_x)
         @test vec_y[:] ≈ y_expected rtol=1e-5
+        
+        finalize(xc)
         
         # Test matrix modification
         A[1, 1] = PetscScalar(100.0)


### PR DESCRIPTION
This fixes ex50 (that solved a poisson equation with Neumann boundary conditions) such that it works with multigrid and provides a code version that does a numerical scaling analysis:

```Julia
$


$julia --project examples/ex50_convergence.jl -convergence_analysis \
-resolutions 65,129,257,513,1025,2049 \
-pc_type mg -ksp_type richardson -pc_mg_levels 8 \
-mg_coarse_ksp_type preonly -mg_coarse_pc_type lu 

Convergence Analysis Results (KSP: richardson, PC: mg):
N     MG Lvl   h          KSP Iters  L2 Error     𝒪(N)     Time (s)   𝒪(Time) 
----- -------- ---------- ---------- ------------ -------- ---------- --------
65    3        0.015385   12         4.142058e-04 1.00     0.0139     0.87    
129   4        0.007752   13         2.093993e-04 1.00     0.0458     1.01    
257   5        0.003891   13         1.052836e-04 1.00     0.1847     1.01    
513   6        0.001949   13         5.278904e-05 1.00     0.7420     1.04    
1025  7        0.000976   14         2.643149e-05 1.00     3.1429     1.00    
2049  7        0.000488   13         1.322501e-05 N/A      12.5204    N/A  
```

The same with a direct solver:
```julia
$



$julia --project examples/ex50_convergence.jl -convergence_analysis \
-resolutions 65,129,257,513,1025,2049 \
-pc_type lu -ksp_type preonly 

Convergence Analysis Results (KSP: preonly, PC: lu):
N     MG Lvl   h          KSP Iters  L2 Error     𝒪(N)     Time (s)   𝒪(Time) 
----- -------- ---------- ---------- ------------ -------- ---------- --------
65    --       0.015385   1          4.142058e-04 1.00     0.0110     0.88    
129   --       0.007752   1          2.093993e-04 1.00     0.0368     1.19    
257   --       0.003891   1          1.052836e-04 1.00     0.1908     1.30    
513   --       0.001949   1          5.278904e-05 1.00     1.1438     1.34    
1025  --       0.000976   1          2.643149e-05 1.00     7.3255     1.38    
2049  --       0.000488   1          1.322501e-05 N/A      49.3041    N/A     
```
 