### PR TITLE
Disables PETSc signal handler

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PETSc"
 uuid = "ace2c81b-2b5f-4b1e-a30d-d662738edfe0"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Boris Kaus <kaus@uni-mainz.de>", "Viral B. Shah <virals@gmail.com>", "Valentin Churavy <v.churavy@gmail.com>", "Erik Schnetter <eschnetter@perimeterinstitute.ca>", "Jeremy E. Kozdon <jeremy@kozdon.net>", "Simon Byrne <simonbyrne@gmail.com>"]
 
 [deps]

--- a/src/init.jl
+++ b/src/init.jl
@@ -58,6 +58,10 @@ end
 
 function initialize(petsclib; log_view::Bool = false, options = String[])
     if !initialized(petsclib)
+
+        # deactivate the signal handler to avoid conflicts with Julia's own handlers when using multithreading
+        push!(options, " -no_signal_handler ")
+
         if log_view || !isempty(options)
             cli_opts = _build_petsc_options(log_view, options)
             prev_opts = get(ENV, "PETSC_OPTIONS", "")


### PR DESCRIPTION
Deactivates the PETSc signal handler by default during initialization. This resolves potential conflicts with Julia's own signal handlers, ensuring more stable operation, particularly in multithreaded environments.

This addresses issue #228 
Identified by @filoferra, solution by @vchuravy  