### PR TITLE
Replace argument-validating @assert with typed exceptions

### DIFF
--- a/src/dmda.jl
+++ b/src/dmda.jl
@@ -67,8 +67,18 @@ function DMDA(
         if isnothing(points_per_proc[d]) || points_per_proc[d] == PETSC_DECIDE
             C_NULL
         else
-            @assert points_per_proc[d] isa Array{PetscLib.PetscInt}
-            @assert length(points_per_proc[d]) == MPI.Comm_size(comm)
+            points_per_proc[d] isa Array{PetscLib.PetscInt} || throw(
+                ArgumentError(
+                    "points_per_proc[$d] must be an Array{$(PetscLib.PetscInt)}, " *
+                    "got $(typeof(points_per_proc[d]))",
+                ),
+            )
+            length(points_per_proc[d]) == MPI.Comm_size(comm) || throw(
+                DimensionMismatch(
+                    "points_per_proc[$d] has $(length(points_per_proc[d])) entries, " *
+                    "but the communicator has $(MPI.Comm_size(comm)) ranks",
+                ),
+            )
             points_per_proc[d]
         end
     end
@@ -170,7 +180,12 @@ function reshapelocalarray(
     if length(Arr) < prod(corners.size) * ndof
         corners = getcorners(da)
     end
-    @assert length(Arr) == prod(corners.size) * ndof
+    length(Arr) == prod(corners.size) * ndof || throw(
+        DimensionMismatch(
+            "array has $(length(Arr)) entries, but the local domain needs " *
+            "$(prod(corners.size) * ndof) ($(corners.size) points x $ndof dofs)",
+        ),
+    )
 
     oArr = OffsetArray(
         reshape(Arr, Int64(ndof), Int64.(corners.size)...),

--- a/src/dmplex.jl
+++ b/src/dmplex.jl
@@ -285,7 +285,7 @@ function DMPlex(
     prefix         = "",
     options...,
 ) where {PetscLib}
-    @assert initialized(getlib(PetscLib))
+    check_initialized(getlib(PetscLib))
 
     dm = LibPETSc.DMCreate(petsclib, comm)
     LibPETSc.DMSetType(petsclib, dm, "plex")
@@ -355,11 +355,13 @@ function DMPlex(
     prefix           = "",
     options...,
 ) where {PetscLib}
-    @assert initialized(getlib(PetscLib))
-    @assert length(faces) == dim
-    @assert length(lower) == dim
-    @assert length(upper) == dim
-    @assert length(periodicity) == dim
+    check_initialized(getlib(PetscLib))
+    for (name, v) in
+        (("faces", faces), ("lower", lower), ("upper", upper), ("periodicity", periodicity))
+        length(v) == dim || throw(
+            DimensionMismatch("$name has length $(length(v)), expected dim = $dim"),
+        )
+    end
 
     PetscInt  = inttype(PetscLib)
     PetscReal = real(scalartype(PetscLib))
@@ -783,7 +785,9 @@ LibPETSc.@for_petsc function dm_project_function!(
     X::AbstractPetscVec{$PetscLib},
 )
     n = length(funcs)
-    @assert length(ctxs) == n "funcs and ctxs must have the same length"
+    length(ctxs) == n || throw(
+        DimensionMismatch("got $n funcs but $(length(ctxs)) ctxs"),
+    )
     funcs_v = collect(funcs)
     ctxs_v  = collect(ctxs)
     LibPETSc.DMProjectFunction(petsclib, dm, time, funcs_v, ctxs_v, mode, X)
@@ -827,7 +831,9 @@ LibPETSc.@for_petsc function dm_compute_l2diff(
     X::AbstractPetscVec{$PetscLib},
 )
     n = length(funcs)
-    @assert length(ctxs) == n "funcs and ctxs must have the same length"
+    length(ctxs) == n || throw(
+        DimensionMismatch("got $n funcs but $(length(ctxs)) ctxs"),
+    )
     funcs_v = collect(funcs)
     ctxs_v  = collect(ctxs)
     return LibPETSc.DMComputeL2Diff(petsclib, dm, time, funcs_v, ctxs_v, X)

--- a/src/dmstag.jl
+++ b/src/dmstag.jl
@@ -62,7 +62,12 @@ function DMStag(
     prefix = "",
     options...,
 ) where {PetscLib, N, N1}
-    @assert N1 == N + 1 "dof_per_node should have length N + 1"
+    N1 == N + 1 || throw(
+        DimensionMismatch(
+            "dof_per_node has length $N1, " *
+            "but a $N-dimensional DMStag needs $(N + 1)",
+        ),
+    )
     PetscInt = inttype(PetscLib)
     opts = Options(petsclib; options...)
 
@@ -77,8 +82,18 @@ function DMStag(
         if isnothing(points_per_proc[d]) || points_per_proc[d] == PETSC_DECIDE
             C_NULL
         else
-            @assert points_per_proc[d] isa Array
-            @assert length(points_per_proc[d]) == MPI.Comm_size(comm)
+            points_per_proc[d] isa Array || throw(
+                ArgumentError(
+                    "points_per_proc[$d] must be an Array, " *
+                    "got $(typeof(points_per_proc[d]))",
+                ),
+            )
+            length(points_per_proc[d]) == MPI.Comm_size(comm) || throw(
+                DimensionMismatch(
+                    "points_per_proc[$d] has $(length(points_per_proc[d])) entries, " *
+                    "but the communicator has $(MPI.Comm_size(comm)) ranks",
+                ),
+            )
             points_per_proc[d]
         end
     end

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,4 +1,40 @@
 """
+    PetscNotInitialized(petsclib)
+
+Thrown when a PETSc object is built or used before its library is initialized.
+
+Call [`initialize`](@ref) on the library first. Every PETSc call needs the
+library up, so this is reported as its own type rather than as an
+`ArgumentError`, which lets callers catch it specifically.
+"""
+struct PetscNotInitialized <: Exception
+    petsclib::Any
+end
+
+function Base.showerror(io::IO, e::PetscNotInitialized)
+    print(io, "PetscNotInitialized: the PETSc library ")
+    # Name the library by its scalar and integer types rather than by printing
+    # the whole handle, which carries an artifact path and drowns the message.
+    try
+        print(io, "(PetscScalar = ", scalartype(e.petsclib))
+        print(io, ", PetscInt = ", inttype(e.petsclib), ") ")
+    catch
+        print(io, e.petsclib, " ")
+    end
+    return print(io, "is not initialized. Call PETSc.initialize(petsclib) first.")
+end
+
+"""
+    check_initialized(petsclib)
+
+Throw [`PetscNotInitialized`](@ref) unless `petsclib` is initialized.
+"""
+function check_initialized(petsclib)
+    initialized(petsclib) || throw(PetscNotInitialized(petsclib))
+    return nothing
+end
+
+"""
    initialized(petsclib)
 
 Check if `petsclib` is initialized

--- a/src/ksp.jl
+++ b/src/ksp.jl
@@ -33,7 +33,7 @@ function KSP(
     prefix::String="",
     options...
 ) where {PetscLib}
-    @assert initialized(getlib(PetscLib))
+    check_initialized(getlib(PetscLib))
 
     petsclib = getlib(PetscLib)
     comm = getcomm(A)
@@ -79,7 +79,7 @@ function KSP(dm::AbstractPetscDM{PetscLib};
     prefix::String="",
     options...
 ) where {PetscLib}
-    @assert initialized(getlib(PetscLib))
+    check_initialized(getlib(PetscLib))
     petsclib = getlib(PetscLib)
     comm = getcomm(dm)
     ksp = LibPETSc.KSPCreate(petsclib,comm)
@@ -158,9 +158,19 @@ function Base.:\(
     ksp::PetscKSP{PetscLib},
     b::Vector{PetscScalar},
 ) where {PetscLib, PetscScalar}
-    @assert PetscScalar == PetscLib.PetscScalar
+    PetscScalar === PetscLib.PetscScalar || throw(
+        ArgumentError(
+            "right-hand side has element type $PetscScalar, " *
+            "but the library uses $(PetscLib.PetscScalar)",
+        ),
+    )
     comm = getcomm(ksp)
-    @assert MPI.Comm_size(comm) == 1
+    MPI.Comm_size(comm) == 1 || throw(
+        ArgumentError(
+            "solving into a Julia Vector requires a sequential KSP, " *
+            "but its communicator spans $(MPI.Comm_size(comm)) ranks",
+        ),
+    )
     PetscInt = PetscLib.PetscInt
 
     petsc_b = LibPETSc.VecCreateSeqWithArray(getlib(PetscLib),comm, PetscInt(1), PetscInt(length(b)), PetscScalar.(b))

--- a/src/mat.jl
+++ b/src/mat.jl
@@ -89,7 +89,7 @@ function MatSeqAIJ(
     nonzeros::Union{Integer, Vector},
 ) where {PetscLib <: PetscLibType}
     comm = MPI.COMM_SELF
-    @assert initialized(petsclib)
+    check_initialized(petsclib)
     PetscInt = petsclib.PetscInt
     if nonzeros isa Integer
         mat = LibPETSc.MatCreateSeqAIJ(petsclib, comm, 
@@ -97,8 +97,18 @@ function MatSeqAIJ(
                 PetscInt(num_cols), 
                 PetscInt(nonzeros), C_NULL)
     else
-        @assert eltype(nonzeros) == petsclib.PetscInt
-        @assert length(nonzeros) >= num_rows
+        eltype(nonzeros) === petsclib.PetscInt || throw(
+            ArgumentError(
+                "nonzeros has element type $(eltype(nonzeros)), " *
+                "but the library uses $(petsclib.PetscInt)",
+            ),
+        )
+        length(nonzeros) >= num_rows || throw(
+            DimensionMismatch(
+                "nonzeros has $(length(nonzeros)) entries, " *
+                "but the matrix has $num_rows rows",
+            ),
+        )
         mat = LibPETSc.MatCreateSeqAIJ(petsclib, comm, 
                 PetscInt(num_rows), 
                 PetscInt(num_cols), 
@@ -123,8 +133,13 @@ function MatSeqDense(
     A::Matrix{PetscScalar},
 ) where {PetscLib <: PetscLibType, PetscScalar}
     comm = MPI.COMM_SELF
-    @assert initialized(petsclib)
-    @assert PetscScalar == petsclib.PetscScalar
+    check_initialized(petsclib)
+    PetscScalar === petsclib.PetscScalar || throw(
+        ArgumentError(
+            "matrix has element type $PetscScalar, " *
+            "but the library uses $(petsclib.PetscScalar)",
+        ),
+    )
     
     PetscInt = petsclib.PetscInt
     # PETSc stores the data pointer directly without copying, so we must keep the
@@ -380,7 +395,7 @@ Set up the interal data for `mat`
 $(_doc_external("Mat/MatSetUp"))
 """
 function setup!(mat::PetscMat{PetscLib}) where {PetscLib}
-    @assert initialized(PetscLib)
+    check_initialized(PetscLib)
     LibPETSc.MatSetUp(PetscLib, mat)
     return mat
 end
@@ -536,8 +551,18 @@ function setvalues!(
     num_rows = length(row0idxs),
     num_cols = length(col0idxs),
 ) where {PetscLib, PetscScalar}
-    @assert PetscScalar == PetscLib.PetscScalar
-    @assert num_rows * num_cols <= length(rowvals)
+    PetscScalar === PetscLib.PetscScalar || throw(
+        ArgumentError(
+            "values have element type $PetscScalar, but the library uses " *
+            "$(PetscLib.PetscScalar)",
+        ),
+    )
+    num_rows * num_cols <= length(rowvals) || throw(
+        DimensionMismatch(
+            "a $(num_rows)x$(num_cols) block needs $(num_rows * num_cols) values, " *
+            "got $(length(rowvals))",
+        ),
+    )
     LibPETSc.MatSetValuesStencil(
         PetscLib,
         M,
@@ -844,9 +869,24 @@ function setvalues!(
     num_rows = length(row0idxs),
     num_cols = length(col0idxs),
 ) where {PetscLib, PetscScalar, PetscInt}
-    @assert PetscScalar == PetscLib.PetscScalar
-    @assert PetscInt == PetscLib.PetscInt
-    @assert num_rows * num_cols <= length(rowvals)
+    PetscScalar === PetscLib.PetscScalar || throw(
+        ArgumentError(
+            "values have element type $PetscScalar, " *
+            "but the library uses $(PetscLib.PetscScalar)",
+        ),
+    )
+    PetscInt === PetscLib.PetscInt || throw(
+        ArgumentError(
+            "indices have element type $PetscInt, " *
+            "but the library uses $(PetscLib.PetscInt)",
+        ),
+    )
+    num_rows * num_cols <= length(rowvals) || throw(
+        DimensionMismatch(
+            "a $(num_rows)x$(num_cols) block needs $(num_rows * num_cols) values, " *
+            "got $(length(rowvals))",
+        ),
+    )
     LibPETSc.MatSetValues(
         PetscLib,
         M,

--- a/src/options.jl
+++ b/src/options.jl
@@ -134,7 +134,11 @@ function parse_options(args::Vector{String})
     i = 1
     opts = Dict{Symbol, Union{String, Nothing}}()
     while i <= length(args)
-        @assert args[i][1] == '-' && length(args[i]) > 1
+        (length(args[i]) > 1 && args[i][1] == '-') || throw(
+            ArgumentError(
+                "expected an option starting with '-', got $(repr(args[i]))",
+            ),
+        )
         if i == length(args) || args[i + 1][1] == '-'
             token = split(args[i][2:end], "=")
             if length(token) == 1

--- a/src/snes.jl
+++ b/src/snes.jl
@@ -35,7 +35,7 @@ function SNES(
     prefix="",
     options...,
 ) where {PetscLib}
-    @assert initialized(getlib(PetscLib))
+    check_initialized(getlib(PetscLib))
 
     petsclib = getlib(PetscLib)
     snes = LibPETSc.SNESCreate(petsclib, comm)

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -69,7 +69,7 @@ $(_doc_external("Vec/VecCreateSeq"))
 """
 function VecSeq(petsclib::PetscLib, n::Int) where {PetscLib <: PetscLibType}
     comm = MPI.COMM_SELF
-    @assert initialized(petsclib)
+    check_initialized(petsclib)
     v = LibPETSc.VecCreateSeq(petsclib, comm, n)
     finalizer(destroy, v)
     return v
@@ -98,8 +98,13 @@ function VecSeq(
     blocksize = 1,
 ) where {PetscLib <: PetscLibType, PetscScalar}
     comm = MPI.COMM_SELF
-    @assert initialized(petsclib)
-    @assert PetscScalar == petsclib.PetscScalar
+    check_initialized(petsclib)
+    PetscScalar === petsclib.PetscScalar || throw(
+        ArgumentError(
+            "array has element type $PetscScalar, " *
+            "but the library uses $(petsclib.PetscScalar)",
+        ),
+    )
     PetscInt = petsclib.PetscInt
     v = LibPETSc.VecCreateSeqWithArray(
         petsclib,
@@ -589,7 +594,7 @@ end
 Creates a sequential PETSc vector of length `n` given a julia array `array`` 
 """
 function VecSeq(petsclib::PetscLib, comm, x::Vector) where {PetscLib <: PetscLibType}
-    @assert initialized(petsclib)
+    check_initialized(petsclib)
     
     v = LibPETSc.VecCreateSeqWithArray(petsclib,comm, 1, length(x), x)    # solution vector
     finalizer(destroy, v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,7 @@ include("dmproduct.jl")     # test for DMProduct example
 include("matshell.jl")      # autowrapped!
 include("test_dmstag.jl")
 include("test_snes.jl")
+include("test_errors.jl")   # argument validation
 include("old_test.jl")
 include("low_level_viewer.jl")  # Low-level viewer convenience functions
 include("low_level_ts.jl")      # Low-level TS functions

--- a/test/test_errors.jl
+++ b/test/test_errors.jl
@@ -1,0 +1,55 @@
+using Test
+using PETSc, MPI
+
+if !Sys.iswindows()
+    MPI.Initialized() || MPI.Init()
+end
+
+@testset "argument validation" begin
+    @testset "PetscNotInitialized" begin
+        e = PETSc.PetscNotInitialized(PETSc.petsclibs[1])
+        msg = sprint(showerror, e)
+        # names the library by its element types, not by dumping the handle
+        @test occursin("PetscScalar", msg)
+        @test occursin("PetscInt", msg)
+        @test occursin("initialize", msg)
+        # a handle that answers neither accessor still produces a message
+        @test occursin("not initialized", sprint(showerror, PETSc.PetscNotInitialized("x")))
+    end
+
+    @testset "parse_options" begin
+        @test PETSc.parse_options(["-ksp_monitor", "-pc_type", "mg"]) ==
+              (ksp_monitor = nothing, pc_type = "mg")
+
+        # each of these used to trip an @assert, and the empty string raised a
+        # BoundsError before the length was checked first
+        for bad in (["notanoption"], ["-"], [""])
+            @test_throws ArgumentError PETSc.parse_options(bad)
+        end
+    end
+
+    for petsclib in PETSc.petsclibs
+        PETSc.initialize(petsclib)
+        PetscScalar = petsclib.PetscScalar
+        PetscInt = petsclib.PetscInt
+
+        @testset "element type mismatch ($PetscScalar)" begin
+            # a Julia array whose element type differs from the library's
+            wrong = PetscScalar === Float64 ? Float32 : Float64
+            @test_throws ArgumentError PETSc.VecSeq(petsclib, wrong[1, 2, 3])
+            @test_throws ArgumentError PETSc.MatSeqDense(petsclib, wrong[1 2; 3 4])
+        end
+
+        @testset "size mismatch ($PetscScalar)" begin
+            # nonzeros shorter than the number of rows
+            @test_throws DimensionMismatch PETSc.MatSeqAIJ(
+                petsclib,
+                PetscInt(4),
+                PetscInt(4),
+                PetscInt[1, 1],
+            )
+        end
+
+        PETSc.finalize(petsclib)
+    end
+end


### PR DESCRIPTION
@assert is for invariants that cannot fail unless the package itself is wrong. This is problematic since it can be disabled and then report the failed expression rather than what the caller did wrong.

Now a PetscNotInitialized is thrown: a new type, so callers can catch that case specifically. 
Eelement type mismatches throw ArgumentError, size mismatches throw DimensionMismatch.