### PR TITLE
Ci fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
     tags: '*'
   pull_request:
 
+# julia-actions/cache prunes stale caches through the GitHub API. 
+# Without `actions: write` that prune fails with HTTP 403 on every run.
+permissions:
+  actions: write
+  contents: read
+
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: always.

--- a/examples/ex62_test.jl
+++ b/examples/ex62_test.jl
@@ -24,19 +24,32 @@ const SOLVER = ["-pc_use_amat",
 """
     run_ex62(args...; tol=nothing) -> Bool
 
-Run ex62.jl with `args`.  Returns `true` when the subprocess exits cleanly.
-If `tol` is given, also checks that the printed `L2 error:` is less than `tol`.
+Run ex62.jl with `args`.  Returns `true` when the subprocess exits cleanly and,
+when `tol` is given, the printed `L2 error:` is below `tol`.
 """
 function run_ex62(args...; tol::Union{Float64, Nothing} = nothing)
     out = IOBuffer()
-    cmd = pipeline(`$JL $EX62 $args`; stdout = out, stderr = devnull)
+    cmd = pipeline(`$JL $EX62 $args`; stdout = out, stderr = out)
     ok  = success(cmd)
-    ok || return false
+    s   = String(take!(out))
+    if !ok
+        println("  ex62 exited non-zero: ", join(args, " "))
+        println(s)
+        return false
+    end
     tol === nothing && return true
-    s = String(take!(out))
     m = match(r"L2 error:\s*([\d.eE+\-]+)", s)
-    m === nothing && return true
-    parse(Float64, m[1]) < tol
+    if m === nothing
+        # A run that stops printing the error must not pass by default.
+        println("  ex62 printed no L2 error: ", join(args, " "))
+        println(s)
+        return false
+    end
+    err = parse(Float64, m[1])
+    println("  L2 error = ", err, " (tol ", tol, ")")
+    err < tol && return true
+    println("  ex62 L2 error exceeds tol: ", join(args, " "))
+    return false
 end
 
 @testset "ex62 serial" begin
@@ -82,26 +95,32 @@ end
   end
 
   # ── dmsnes_check: Jacobian consistency via finite differences ────────────────
+  # What these assert is that the run completes with a consistent Jacobian. 
+  # They use the default solver, so the reported L2 error is set by the default KSP
+  # tolerance and the 1e-4 finite-difference step rather than by the discretization. 
+  # The tolerances below sit about two decades above the observed values so 
+  # they bound the result without tracking round-off. 
+  # Measured: 1.3e-9, 1.5e-10, 2.6e-9.
 
   @testset "Q2/Q1 quad 2D — dmsnes_check" begin
     @test run_ex62(
       "-sol","quadratic","-dm_plex_simplex","0",
       "-vel_petscspace_degree","2","-pres_petscspace_degree","1",
-      "-dmsnes_check","0.0001"; tol = 2e-9)
+      "-dmsnes_check","0.0001"; tol = 1e-7)
   end
 
   @testset "P2/P1 simplex 2D — dmsnes_check" begin
     @test run_ex62(
       "-sol","quadratic",
       "-vel_petscspace_degree","2","-pres_petscspace_degree","1",
-      "-dmsnes_check","0.0001"; tol = 1e-9)
+      "-dmsnes_check","0.0001"; tol = 1e-8)
   end
 
   @testset "P3/P2 simplex 2D — quadratic MMS dmsnes_check" begin
     @test run_ex62(
       "-sol","quadratic",
       "-vel_petscspace_degree","3","-pres_petscspace_degree","2",
-      "-dmsnes_check","0.0001"; tol = 1e-8)
+      "-dmsnes_check","0.0001"; tol = 1e-7)
   end
 
   # ── Trig MMS: measure convergence rate (Q2 → ~4–8× per refinement) ──────────
@@ -171,12 +190,18 @@ end
       "-fieldsplit_velocity_pc_type","lu","-fieldsplit_pressure_pc_type","jacobi"; tol = 1e-3)
   end
 
-  @testset "P2/P1 simplex 2D — block triangular multiplicative (L²≈3e-7)" begin
+  # The quadratic MMS is exact for P2/P1, so a fully converged solve leaves only round-off. 
+  # At -ksp_rtol 1e-9 the residual has not fallen far enough for that,
+  # and the reported error tracks where fgmres happened to stop. 
+  # That depends on which kernels OpenBLAS dispatches for the runner CPU: 
+  # measured 1.5e-7, 1.7e-7, 5.6e-7 and 3.3e-6 across four kernel paths, straddling this tolerance.
+  # Solving to 1e-12 measures the discretization instead and collapses the spread to 1.5e-10 - 4.9e-10.
+  @testset "P2/P1 simplex 2D — block triangular multiplicative (L²≈4e-10)" begin
     @test run_ex62(
       "-sol","quadratic","-dm_refine","2",
       "-vel_petscspace_degree","2","-pres_petscspace_degree","1","-petscds_jac_pre","0",
       "-snes_error_if_not_converged",
-      "-ksp_type","fgmres","-ksp_gmres_restart","100","-ksp_rtol","1.0e-9","-ksp_error_if_not_converged",
+      "-ksp_type","fgmres","-ksp_gmres_restart","100","-ksp_rtol","1.0e-12","-ksp_error_if_not_converged",
       "-pc_type","fieldsplit","-pc_fieldsplit_type","multiplicative",
       "-fieldsplit_velocity_pc_type","lu","-fieldsplit_pressure_pc_type","jacobi"; tol = 1e-6)
   end
@@ -234,7 +259,9 @@ end
       "-ksp_rtol","1e-9"; tol = 0.25)
   end
 
-  @testset "Q2/Q1 quad 2D — quadratic MMS GMG on velocity (L²≈4e-7)" begin
+  # Same reasoning as the multiplicative case above: solved to 1e-12 so the
+  # reported error is the discretization error, not the iteration count.
+  @testset "Q2/Q1 quad 2D — quadratic MMS GMG on velocity (L²≈3e-10)" begin
     @test run_ex62(
       "-sol","quadratic","-dm_plex_simplex","0","-dm_refine","2",
       "-vel_petscspace_degree","2","-pres_petscspace_degree","1",
@@ -245,9 +272,9 @@ end
       "-fieldsplit_velocity_ksp_type","fgmres",
       "-fieldsplit_velocity_pc_type","mg",
       "-fieldsplit_velocity_mg_coarse_pc_type","svd",
-      "-fieldsplit_pressure_ksp_rtol","1e-9",
+      "-fieldsplit_pressure_ksp_rtol","1e-12",
       "-fieldsplit_pressure_pc_type","jacobi",
-      "-ksp_type","fgmres","-ksp_rtol","1e-9"; tol = 1e-5)
+      "-ksp_type","fgmres","-ksp_rtol","1e-12"; tol = 1e-5)
   end
 
 end

--- a/test/dmplex.jl
+++ b/test/dmplex.jl
@@ -227,8 +227,12 @@ for petsclib in PETSc.petsclibs
             PetscInt_t(-1),
         )
         @test convert(Ptr{Cvoid}, fe2) != C_NULL
-        # PetscFEDestroy auto-wrapper is broken (ReadOnlyMemoryError); FEs are
-        # reference-counted by PETSc and freed with the parent DM or at finalize.
+        # FEs are the one object this file does not destroy. The autowrapped
+        # PetscFEDestroy passes the handle where PETSc expects a pointer to it,
+        # so calling it raises ReadOnlyMemoryError. That leaks the FE, but
+        # PetscFE is a bare Ptr with no finalizer attached, so unlike a leaked
+        # DM or Vec it cannot fire after the library is torn down. Fixing the
+        # generated wrapper is the real fix.
     end
 
     # ── High-level: options-based constructor ────────────────────────────────
@@ -240,6 +244,8 @@ for petsclib in PETSc.petsclibs
         @test convert(Ptr{Cvoid}, dm) != C_NULL
         @test LibPETSc.DMGetType(petsclib, dm) == "plex"
         @test LibPETSc.DMGetDimension(petsclib, dm) == 2
+
+        PETSc.destroy(dm)
     end
 
     # ── High-level: explicit box constructor ─────────────────────────────────
@@ -253,11 +259,15 @@ for petsclib in PETSc.petsclibs
             dm_tri = PETSc.DMPlex(petsclib, _TC, 2, true, [4, 4])
             @test dm_tri isa LibPETSc.PetscDM
             @test LibPETSc.DMGetDimension(petsclib, dm_tri) == 2
+            PETSc.destroy(dm_tri)
         end
 
         dm_3d = PETSc.DMPlex(petsclib, _TC, 3, false, [2, 2, 2])
         @test dm_3d isa LibPETSc.PetscDM
         @test LibPETSc.DMGetDimension(petsclib, dm_3d) == 3
+
+        PETSc.destroy(dm_hex)
+        PETSc.destroy(dm_3d)
     end
 
     # ── isplexsimplex ────────────────────────────────────────────────────────
@@ -267,7 +277,10 @@ for petsclib in PETSc.petsclibs
         if real(PetscScalar_t) != Float32
             dm_tri = PETSc.DMPlex(petsclib, _TC, 2, true,  [4, 4])
             @test PETSc.isplexsimplex(dm_tri) == true
+            PETSc.destroy(dm_tri)
         end
+
+        PETSc.destroy(dm_hex)
     end
 
     # ── plexdistribute! (serial: mesh stays on one rank) ────────────────────
@@ -277,6 +290,11 @@ for petsclib in PETSc.petsclibs
         # (no redistribution needed).  We just check it does not throw.
         dm_par = @test_nowarn PETSc.plexdistribute!(dm; overlap = 0)
         @test dm_par isa LibPETSc.PetscDM
+
+        # destroy skips a NULL pointer, so this is a no-op on one rank and
+        # frees the redistributed mesh on several.
+        PETSc.destroy(dm_par)
+        PETSc.destroy(dm)
     end
 
     # ── petsc_setname! ───────────────────────────────────────────────────────
@@ -285,6 +303,8 @@ for petsclib in PETSc.petsclibs
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         @test_nowarn PETSc.petsc_setname!(petsclib, dm, "testmesh")
         @test_nowarn PETSc.petsc_setname!(petsclib, fe, "temperature")
+
+        PETSc.destroy(dm)
     end
 
     # ── getlabel ─────────────────────────────────────────────────────────────
@@ -297,6 +317,8 @@ for petsclib in PETSc.petsclibs
         # Non-existent label → C_NULL
         lbl_none = PETSc.getlabel(dm, "no_such_label_xyz")
         @test lbl_none == C_NULL
+
+        PETSc.destroy(dm)
     end
 
     # ── fe_create_default ────────────────────────────────────────────────────
@@ -334,6 +356,9 @@ for petsclib in PETSc.petsclibs
 
         ds = PETSc.getds(dm)
         @test ds isa PETSc.PetscDS
+
+        # ds belongs to dm, so destroying dm is enough.
+        PETSc.destroy(dm)
     end
 
     # ── PetscDS: set_constants! ──────────────────────────────────────────────
@@ -344,6 +369,8 @@ for petsclib in PETSc.petsclibs
         PETSc.createds!(dm)
         ds = PETSc.getds(dm)
         @test_nowarn PETSc.set_constants!(ds, [1.0, 2.0, 3.0])
+
+        PETSc.destroy(dm)
     end
 
     # ── PetscDS: set_residual! / set_jacobian! / set_exact_solution! ─────────
@@ -357,6 +384,8 @@ for petsclib in PETSc.petsclibs
         @test_nowarn PETSc.set_residual!(ds, 0, _dm_f0_ptr, _dm_f1_ptr)
         @test_nowarn PETSc.set_jacobian!(ds, 0, 0, C_NULL, C_NULL, C_NULL, _dm_g3_ptr)
         @test_nowarn PETSc.set_exact_solution!(ds, 0, _dm_exact_ptr)
+
+        PETSc.destroy(dm)
     end
 
     # ── PetscDS: set_jacobian_preconditioner! ────────────────────────────────
@@ -368,6 +397,8 @@ for petsclib in PETSc.petsclibs
         ds = PETSc.getds(dm)
         @test_nowarn PETSc.set_jacobian_preconditioner!(
             ds, 0, 0, C_NULL, C_NULL, C_NULL, _dm_g3_ptr)
+
+        PETSc.destroy(dm)
     end
 
     # ── dm_create_global_vec / dm_create_local_vec ───────────────────────────
@@ -382,6 +413,10 @@ for petsclib in PETSc.petsclibs
 
         lvec = PETSc.dm_create_local_vec(dm)
         @test convert(Ptr{Cvoid}, lvec) != C_NULL
+
+        PETSc.destroy(gvec)
+        PETSc.destroy(lvec)
+        PETSc.destroy(dm)
     end
 
     # ── dm_global_to_local! ──────────────────────────────────────────────────
@@ -394,6 +429,10 @@ for petsclib in PETSc.petsclibs
         gvec = PETSc.dm_create_global_vec(dm)
         lvec = PETSc.dm_create_local_vec(dm)
         @test_nowarn PETSc.dm_global_to_local!(dm, gvec, lvec)
+
+        PETSc.destroy(gvec)
+        PETSc.destroy(lvec)
+        PETSc.destroy(dm)
     end
 
     # ── dmclone ──────────────────────────────────────────────────────────────
@@ -406,6 +445,9 @@ for petsclib in PETSc.petsclibs
         @test convert(Ptr{Cvoid}, dm2) != convert(Ptr{Cvoid}, dm)
         @test LibPETSc.DMGetDimension(petsclib, dm2) == 2
         @test PETSc.isplexsimplex(dm2) == false
+
+        PETSc.destroy(dm2)
+        PETSc.destroy(dm)
     end
 
     # ── dm_get_coarse (non-hierarchical mesh → NULL coarse) ──────────────────
@@ -414,6 +456,9 @@ for petsclib in PETSc.petsclibs
         cdm = PETSc.dm_get_coarse(dm)
         @test cdm isa LibPETSc.PetscDM
         @test convert(Ptr{Cvoid}, cdm) == C_NULL
+
+        # cdm is borrowed from dm (and NULL here), so only dm is destroyed.
+        PETSc.destroy(dm)
     end
 
     # ── dm_copy_disc! ────────────────────────────────────────────────────────
@@ -432,6 +477,9 @@ for petsclib in PETSc.petsclibs
         # After copy_disc, the destination should also have a DS
         ds_dst = PETSc.getds(dm_dst)
         @test ds_dst isa PETSc.PetscDS
+
+        PETSc.destroy(dm_dst)
+        PETSc.destroy(dm_src)
     end
 
     # ── Multi-field DS setup ──────────────────────────────────────────────────
@@ -451,6 +499,9 @@ for petsclib in PETSc.petsclibs
 
         gvec = PETSc.dm_create_global_vec(dm)
         @test convert(Ptr{Cvoid}, gvec) != C_NULL
+
+        PETSc.destroy(gvec)
+        PETSc.destroy(dm)
     end
 
     # ── add_boundary! ────────────────────────────────────────────────────────
@@ -471,6 +522,8 @@ for petsclib in PETSc.petsclibs
         )
         @test bd isa PetscInt_t
         @test bd >= 0
+
+        PETSc.destroy(dm)
     end
 
     # ── dm_project_function! + dm_compute_l2diff ─────────────────────────────
@@ -493,6 +546,9 @@ for petsclib in PETSc.petsclibs
         l2err = PETSc.dm_compute_l2diff(petsclib, dm, 0.0,
                                          [_dm_exact_ptr], nothing, u)
         @test l2err ≈ 0.0 atol = 1e-12
+
+        PETSc.destroy(u)
+        PETSc.destroy(dm)
     end
 
     # ── dm_project_function! (simplex mesh) ──────────────────────────────────
@@ -511,6 +567,9 @@ for petsclib in PETSc.petsclibs
         l2err = PETSc.dm_compute_l2diff(petsclib, dm, 0.0,
                                          [_dm_exact_ptr], nothing, u)
         @test l2err ≈ 0.0 atol = 1e-12
+
+        PETSc.destroy(u)
+        PETSc.destroy(dm)
     end
 
     # ── 3D hex mesh basic sanity ──────────────────────────────────────────────
@@ -529,6 +588,9 @@ for petsclib in PETSc.petsclibs
         l2err = PETSc.dm_compute_l2diff(petsclib, dm, 0.0,
                                          [_dm_exact_ptr], nothing, u)
         @test l2err ≈ 0.0 atol = 1e-12
+
+        PETSc.destroy(u)
+        PETSc.destroy(dm)
     end
     end # PetscScalar_t == Float64
 


### PR DESCRIPTION
The ex62 multiplicative fieldsplit test asserted L2 < 1e-6 while solving only to -ksp_rtol 1e-9. The quadratic MMS is exact for P2/P1, so at that tolerance the reported error measures where fgmres stopped rather than the discretization, and that depends on which kernels OpenBLAS dispatches for the runner CPU.

Solve to 1e-12 instead, which collapses the spread to 1.5e-10 - 4.9e-10. Apply the same fix to the GMG case, and loosen the three `dmsnes_check` tolerances

Also destroy leftover objects in DMPlex tests. Maybe that was a reason for the multiple SEGVFAULTS?
