### PR TITLE
Fix more object leaks and destruction

### DIFF
--- a/src/autowrapped/PetscFE_wrappers.jl
+++ b/src/autowrapped/PetscFE_wrappers.jl
@@ -302,12 +302,16 @@ $(_doc_external("DM/PetscFEDestroy"))
 function PetscFEDestroy(petsclib::PetscLibType, fem::PetscFE) end
 
 @for_petsc function PetscFEDestroy(petsclib::$UnionPetscLib, fem::PetscFE )
+	# PetscFE is a bare pointer, and PetscFEDestroy takes a pointer to it so it
+	# can null the caller's handle. Passing `fem` itself made PETSc dereference
+	# the FE as if it were the outer pointer, which raised ReadOnlyMemoryError.
+	fem_ = Ref(fem)
 
     @chk ccall(
                (:PetscFEDestroy, $petsc_library),
                PetscErrorCode,
                (Ptr{PetscFE},),
-               fem,
+               fem_,
               )
 
 

--- a/src/autowrapped/petsc_library.jl
+++ b/src/autowrapped/petsc_library.jl
@@ -59,7 +59,7 @@ end
 
 # Convenience constructor from petsclib instance
 PetscVec(lib::PetscLib) where {PetscLib} = PetscVec{PetscLib}()
-PetscVec(ptr::CVec, lib::PetscLib, age::Int = 0) where {PetscLib} = PetscVec{PetscLib}(ptr, age)
+PetscVec(ptr::CVec, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscVec{PetscLib}(ptr, age)
 Base.convert(::Type{CVec}, v::AbstractPetscVec) = v.ptr
 Base.unsafe_convert(::Type{CVec}, v::AbstractPetscVec) = v.ptr
 # ------------------------------------------------------
@@ -80,7 +80,7 @@ end
 
 # Convenience constructor from petsclib instance
 PetscMat(lib::PetscLib) where {PetscLib} = PetscMat{PetscLib}()
-PetscMat(ptr::CMat, lib::PetscLib, age::Int = 0) where {PetscLib} = PetscMat{PetscLib}(ptr, age)
+PetscMat(ptr::CMat, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscMat{PetscLib}(ptr, age)
 Base.convert(::Type{CMat}, v::AbstractPetscMat) = v.ptr
 Base.unsafe_convert(::Type{CMat}, v::AbstractPetscMat) = v.ptr
 # ------------------------------------------------------
@@ -104,7 +104,7 @@ end
 
 # Convenience constructor from petsclib instance
 PetscKSP(lib::PetscLib) where {PetscLib} = PetscKSP{PetscLib}()
-PetscKSP(ptr::CKSP, lib::PetscLib, age::Int = 0) where {PetscLib} = PetscKSP{PetscLib}(ptr, age)
+PetscKSP(ptr::CKSP, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscKSP{PetscLib}(ptr, age)
 Base.convert(::Type{CKSP}, v::AbstractPetscKSP) = v.ptr
 Base.unsafe_convert(::Type{CKSP}, v::AbstractPetscKSP) = v.ptr
 
@@ -138,8 +138,8 @@ end
 
 # Convenience constructor from petsclib instance
 PetscSNES(lib::PetscLib) where {PetscLib} = PetscSNES{PetscLib}()
-PetscSNES(ptr::Ptr, lib::PetscLib, f!::Function, updateJ!::Function, user_ctx::Any=nothing, age::Int = 0) where {PetscLib} = PetscSNES{PetscLib}(ptr, age, f!, updateJ!, user_ctx)
-PetscSNES(ptr::Ptr, lib::PetscLib, age::Int = 0) where {PetscLib} = PetscSNES{PetscLib}(ptr, age)
+PetscSNES(ptr::Ptr, lib::PetscLib, f!::Function, updateJ!::Function, user_ctx::Any=nothing, age::Int = lib.age) where {PetscLib} = PetscSNES{PetscLib}(ptr, age, f!, updateJ!, user_ctx)
+PetscSNES(ptr::Ptr, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscSNES{PetscLib}(ptr, age)
 Base.convert(::Type{CSNES}, v::AbstractPetscSNES) = v.ptr
 Base.unsafe_convert(::Type{CSNES}, v::AbstractPetscSNES) = v.ptr
 # ------------------------------------------------------
@@ -160,7 +160,7 @@ end
 
 # Convenience constructor from petsclib instance
 PetscDM(lib::PetscLib) where {PetscLib} = PetscDM{PetscLib}()
-PetscDM(ptr::CDM, lib::PetscLib, age::Int = 0) where {PetscLib} = PetscDM{PetscLib}(ptr, age)
+PetscDM(ptr::CDM, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscDM{PetscLib}(ptr, age)
 Base.convert(::Type{CDM}, v::AbstractPetscDM) = v.ptr
 Base.unsafe_convert(::Type{CDM}, v::AbstractPetscDM) = v.ptr
 # ------------------------------------------------------

--- a/src/autowrapped/petsc_library.jl
+++ b/src/autowrapped/petsc_library.jl
@@ -58,7 +58,7 @@ mutable struct PetscVec{PetscLib} <: AbstractPetscVec{PetscLib}
 end
 
 # Convenience constructor from petsclib instance
-PetscVec(lib::PetscLib) where {PetscLib} = PetscVec{PetscLib}()
+PetscVec(lib::PetscLib) where {PetscLib} = PetscVec{PetscLib}(C_NULL, lib.age)
 PetscVec(ptr::CVec, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscVec{PetscLib}(ptr, age)
 Base.convert(::Type{CVec}, v::AbstractPetscVec) = v.ptr
 Base.unsafe_convert(::Type{CVec}, v::AbstractPetscVec) = v.ptr
@@ -79,7 +79,7 @@ mutable struct PetscMat{PetscLib} <: AbstractPetscMat{PetscLib}
 end
 
 # Convenience constructor from petsclib instance
-PetscMat(lib::PetscLib) where {PetscLib} = PetscMat{PetscLib}()
+PetscMat(lib::PetscLib) where {PetscLib} = PetscMat{PetscLib}(C_NULL, lib.age)
 PetscMat(ptr::CMat, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscMat{PetscLib}(ptr, age)
 Base.convert(::Type{CMat}, v::AbstractPetscMat) = v.ptr
 Base.unsafe_convert(::Type{CMat}, v::AbstractPetscMat) = v.ptr
@@ -103,7 +103,7 @@ mutable struct PetscKSP{PetscLib} <: AbstractPetscKSP{PetscLib}
 end
 
 # Convenience constructor from petsclib instance
-PetscKSP(lib::PetscLib) where {PetscLib} = PetscKSP{PetscLib}()
+PetscKSP(lib::PetscLib) where {PetscLib} = PetscKSP{PetscLib}(C_NULL, lib.age)
 PetscKSP(ptr::CKSP, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscKSP{PetscLib}(ptr, age)
 Base.convert(::Type{CKSP}, v::AbstractPetscKSP) = v.ptr
 Base.unsafe_convert(::Type{CKSP}, v::AbstractPetscKSP) = v.ptr
@@ -137,7 +137,7 @@ mutable struct PetscSNES{PetscLib} <: AbstractPetscSNES{PetscLib}
 end
 
 # Convenience constructor from petsclib instance
-PetscSNES(lib::PetscLib) where {PetscLib} = PetscSNES{PetscLib}()
+PetscSNES(lib::PetscLib) where {PetscLib} = PetscSNES{PetscLib}(C_NULL, lib.age)
 PetscSNES(ptr::Ptr, lib::PetscLib, f!::Function, updateJ!::Function, user_ctx::Any=nothing, age::Int = lib.age) where {PetscLib} = PetscSNES{PetscLib}(ptr, age, f!, updateJ!, user_ctx)
 PetscSNES(ptr::Ptr, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscSNES{PetscLib}(ptr, age)
 Base.convert(::Type{CSNES}, v::AbstractPetscSNES) = v.ptr
@@ -159,7 +159,7 @@ mutable struct PetscDM{PetscLib} <: AbstractPetscDM{PetscLib}
 end
 
 # Convenience constructor from petsclib instance
-PetscDM(lib::PetscLib) where {PetscLib} = PetscDM{PetscLib}()
+PetscDM(lib::PetscLib) where {PetscLib} = PetscDM{PetscLib}(C_NULL, lib.age)
 PetscDM(ptr::CDM, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscDM{PetscLib}(ptr, age)
 Base.convert(::Type{CDM}, v::AbstractPetscDM) = v.ptr
 Base.unsafe_convert(::Type{CDM}, v::AbstractPetscDM) = v.ptr

--- a/src/dm.jl
+++ b/src/dm.jl
@@ -36,7 +36,7 @@ is garbage collected, but can be called explicitly to free resources immediately
 $(_doc_external("DM/DMDestroy"))
 """
 function destroy(dm::AbstractPetscDM{PetscLib}) where {PetscLib}
-    if !(finalized(PetscLib)) && dm.ptr != C_NULL 
+    if isdestroyable(dm, PetscLib)
         LibPETSc.DMDestroy(PetscLib, dm)
     end
     dm.ptr = C_NULL

--- a/src/init.jl
+++ b/src/init.jl
@@ -120,6 +120,26 @@ $(_doc_external("Sys/PetscFinalized"))
 """
 finalized(petsclib) = LibPETSc.PetscFinalized(petsclib)
 
+"""
+    isdestroyable(obj, ::Type{PetscLib})
+
+Whether `obj` still refers to a PETSc object this process is allowed to destroy.
+
+It is not destroyable when the library is finalized, when the pointer is already
+null, or when the object predates the current initialize/finalize cycle.
+`initialize` and `finalize` both bump `petsclib.age`, and every object records
+the age it was created under. `PetscFinalize` frees everything it owns,
+including the inner communicator, so calling `xxxDestroy` on an object from an
+earlier cycle reaches a communicator that no longer exists and aborts inside
+MPI with "Invalid communicator". That happens from a GC finalizer, so it
+surfaces at an arbitrary later point rather than where the object was dropped.
+"""
+function isdestroyable(obj, ::Type{PetscLib}) where {PetscLib}
+    finalized(PetscLib) && return false
+    obj.ptr == C_NULL && return false
+    return obj.age == getlib(PetscLib).age
+end
+
 function _build_petsc_options(log_view::Bool, options)
     opts = String[]
     if log_view

--- a/src/ksp.jl
+++ b/src/ksp.jl
@@ -174,7 +174,7 @@ end
 
 
 function destroy(ksp::PetscKSP{PetscLib}) where {PetscLib}
-    if !(finalized(PetscLib)) && ksp.ptr != C_NULL
+    if isdestroyable(ksp, PetscLib)
         LibPETSc.KSPDestroy(PetscLib, ksp)
     end
     ksp.ptr = C_NULL

--- a/src/mat.jl
+++ b/src/mat.jl
@@ -470,8 +470,14 @@ is garbage collected, but can be called explicitly to free resources immediately
 $(_doc_external("Mat/MatDestroy"))
 """
 function destroy(m::AbstractPetscMat{PetscLib}) where {PetscLib}
+    # Drop the backing arrays: Julia-side bookkeeping
+    # that has to go when PETSc no longer owns the matrix.
     pop!(_MATSEQAIJ_WITHARRAYS_STORAGE, m.ptr, nothing)
-    return LibPETSc.MatDestroy(PetscLib, m)
+    if isdestroyable(m, PetscLib)
+        LibPETSc.MatDestroy(PetscLib, m)
+    end
+    m.ptr = C_NULL
+    return nothing
 end
 
 const MatAT{PetscLib, PetscScalar} = Union{

--- a/src/options.jl
+++ b/src/options.jl
@@ -87,6 +87,8 @@ function Options(petsclib::PetscLibType; kwargs...)
 end
 
 function destroy(opts::AbstractPetscOptions{PetscLib}) where {PetscLib}
+    # PetscOptions carries no `age`, so this cannot use `isdestroyable`. 
+    # TODO: Adding the field would make it consistent with Vec, Mat, KSP, SNES and DM.
     if !(finalized(PetscLib)) && opts.ptr != C_NULL
         LibPETSc.PetscOptionsDestroy(PetscLib, opts)
     end

--- a/src/snes.jl
+++ b/src/snes.jl
@@ -251,7 +251,7 @@ function destroy(snes::AbstractPetscSNES{PetscLib}) where {PetscLib}
         destroy(snes.opts)
         snes.opts = nothing
     end
-    if !(finalized(PetscLib)) && snes.ptr != C_NULL
+    if isdestroyable(snes, PetscLib)
         LibPETSc.SNESDestroy(PetscLib, snes)
     end
     snes.ptr = C_NULL

--- a/src/vec.jl
+++ b/src/vec.jl
@@ -206,7 +206,24 @@ end
 
 
 
-destroy(m::AbstractPetscVec{PetscLib}) where {PetscLib} = LibPETSc.VecDestroy(PetscLib,m)
+"""
+    destroy(v::AbstractPetscVec)
+
+Destroy a PETSc vector and release its resources.
+
+Safe to call more than once, and safe to reach as a GC finalizer after the
+library has been finalized or re-initialized: see [`isdestroyable`](@ref).
+
+# External Links
+$(_doc_external("Vec/VecDestroy"))
+"""
+function destroy(m::AbstractPetscVec{PetscLib}) where {PetscLib}
+    if isdestroyable(m, PetscLib)
+        LibPETSc.VecDestroy(PetscLib, m)
+    end
+    m.ptr = C_NULL
+    return nothing
+end
 
 
 """

--- a/test/dmplex.jl
+++ b/test/dmplex.jl
@@ -28,6 +28,11 @@ const PetscReal   = Float64
 # Serial-safe communicator (shared across all lib loops)
 const _TC = Sys.iswindows() ? LibPETSc.PETSC_COMM_SELF : MPI.COMM_SELF
 
+# PetscFE is a bare Ptr, so no finalizer is attached and every FE created here
+# has to be released with LibPETSc.PetscFEDestroy or it lives until
+# PetscFinalize. Where an FE is handed to a DM, DMSetField takes its own
+# reference, so the destroy can follow immediately after setfield!.
+
 # Intel Mac (x86_64) crashes inside DMPlex + PetscFE operations with the
 # current PETSc_jll binary.  Guard the PETSc-dependent testset; the pure-Julia
 # vtk_merge_tensor! tests below are unaffected and still run.
@@ -207,7 +212,7 @@ for petsclib in PETSc.petsclibs
             pop!(opts)
         end
         @test convert(Ptr{Cvoid}, fe) != C_NULL
-        # Note: PetscFEDestroy has a broken auto-wrapper; let PETSc manage FE lifetime.
+        LibPETSc.PetscFEDestroy(petsclib, fe)
     end
 
     @testset "Low-level: PetscFECreateLagrange" begin
@@ -219,6 +224,7 @@ for petsclib in PETSc.petsclibs
             PetscInt_t(-1),
         )
         @test convert(Ptr{Cvoid}, fe1) != C_NULL
+        LibPETSc.PetscFEDestroy(petsclib, fe1)
         fe2 = LibPETSc.PetscFECreateLagrange(
             petsclib, _TC,
             PetscInt_t(2), PetscInt_t(1),
@@ -227,12 +233,7 @@ for petsclib in PETSc.petsclibs
             PetscInt_t(-1),
         )
         @test convert(Ptr{Cvoid}, fe2) != C_NULL
-        # FEs are the one object this file does not destroy. The autowrapped
-        # PetscFEDestroy passes the handle where PETSc expects a pointer to it,
-        # so calling it raises ReadOnlyMemoryError. That leaks the FE, but
-        # PetscFE is a bare Ptr with no finalizer attached, so unlike a leaked
-        # DM or Vec it cannot fire after the library is torn down. Fixing the
-        # generated wrapper is the real fix.
+        LibPETSc.PetscFEDestroy(petsclib, fe2)
     end
 
     # ── High-level: options-based constructor ────────────────────────────────
@@ -303,6 +304,7 @@ for petsclib in PETSc.petsclibs
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         @test_nowarn PETSc.petsc_setname!(petsclib, dm, "testmesh")
         @test_nowarn PETSc.petsc_setname!(petsclib, fe, "temperature")
+        LibPETSc.PetscFEDestroy(petsclib, fe)
 
         PETSc.destroy(dm)
     end
@@ -325,9 +327,11 @@ for petsclib in PETSc.petsclibs
     @testset "fe_create_default" begin
         fe = PETSc.fe_create_default(petsclib, _TC, 2, 1, false; degree = 1)
         @test convert(Ptr{Cvoid}, fe) != C_NULL
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         if real(PetscScalar_t) != Float32
             fe2 = PETSc.fe_create_default(petsclib, _TC, 2, 2, true; degree = 2)
             @test convert(Ptr{Cvoid}, fe2) != C_NULL
+            LibPETSc.PetscFEDestroy(petsclib, fe2)
         end
     end
 
@@ -335,14 +339,18 @@ for petsclib in PETSc.petsclibs
     @testset "fe_create_lagrange" begin
         fe_q1 = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         @test convert(Ptr{Cvoid}, fe_q1) != C_NULL
+        LibPETSc.PetscFEDestroy(petsclib, fe_q1)
         fe_q2 = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 2)
         @test convert(Ptr{Cvoid}, fe_q2) != C_NULL
+        LibPETSc.PetscFEDestroy(petsclib, fe_q2)
         if real(PetscScalar_t) != Float32
             fe_p1 = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, true, 1)
             @test convert(Ptr{Cvoid}, fe_p1) != C_NULL
+            LibPETSc.PetscFEDestroy(petsclib, fe_p1)
         end
         fe_3d = PETSc.fe_create_lagrange(petsclib, _TC, 3, 3, false, 1)
         @test convert(Ptr{Cvoid}, fe_3d) != C_NULL
+        LibPETSc.PetscFEDestroy(petsclib, fe_3d)
     end
 
     # ── setfield! / createds! / getds ────────────────────────────────────────
@@ -352,6 +360,7 @@ for petsclib in PETSc.petsclibs
         PETSc.petsc_setname!(petsclib, fe, "u")
 
         @test_nowarn PETSc.setfield!(dm, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         @test_nowarn PETSc.createds!(dm)
 
         ds = PETSc.getds(dm)
@@ -366,6 +375,7 @@ for petsclib in PETSc.petsclibs
         dm = PETSc.DMPlex(petsclib, _TC, 2, false, [4, 4])
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         PETSc.setfield!(dm, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         PETSc.createds!(dm)
         ds = PETSc.getds(dm)
         @test_nowarn PETSc.set_constants!(ds, [1.0, 2.0, 3.0])
@@ -378,6 +388,7 @@ for petsclib in PETSc.petsclibs
         dm = PETSc.DMPlex(petsclib, _TC, 2, false, [4, 4])
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         PETSc.setfield!(dm, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         PETSc.createds!(dm)
         ds = PETSc.getds(dm)
 
@@ -393,6 +404,7 @@ for petsclib in PETSc.petsclibs
         dm = PETSc.DMPlex(petsclib, _TC, 2, false, [4, 4])
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         PETSc.setfield!(dm, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         PETSc.createds!(dm)
         ds = PETSc.getds(dm)
         @test_nowarn PETSc.set_jacobian_preconditioner!(
@@ -406,6 +418,7 @@ for petsclib in PETSc.petsclibs
         dm = PETSc.DMPlex(petsclib, _TC, 2, false, [4, 4])
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         PETSc.setfield!(dm, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         PETSc.createds!(dm)
 
         gvec = PETSc.dm_create_global_vec(dm)
@@ -424,6 +437,7 @@ for petsclib in PETSc.petsclibs
         dm = PETSc.DMPlex(petsclib, _TC, 2, false, [4, 4])
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         PETSc.setfield!(dm, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         PETSc.createds!(dm)
 
         gvec = PETSc.dm_create_global_vec(dm)
@@ -467,6 +481,7 @@ for petsclib in PETSc.petsclibs
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         PETSc.petsc_setname!(petsclib, fe, "u")
         PETSc.setfield!(dm_src, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         PETSc.createds!(dm_src)
         ds_src = PETSc.getds(dm_src)
         PETSc.set_exact_solution!(ds_src, 0, _dm_exact_ptr)
@@ -491,7 +506,9 @@ for petsclib in PETSc.petsclibs
         PETSc.petsc_setname!(petsclib, fe_u, "velocity")
         PETSc.petsc_setname!(petsclib, fe_p, "pressure")
         @test_nowarn PETSc.setfield!(dm, 0, fe_u)
+        LibPETSc.PetscFEDestroy(petsclib, fe_u)
         @test_nowarn PETSc.setfield!(dm, 1, fe_p)
+        LibPETSc.PetscFEDestroy(petsclib, fe_p)
         @test_nowarn PETSc.createds!(dm)
 
         ds = PETSc.getds(dm)
@@ -510,6 +527,7 @@ for petsclib in PETSc.petsclibs
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         PETSc.petsc_setname!(petsclib, fe, "u")
         PETSc.setfield!(dm, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         PETSc.createds!(dm)
 
         label = PETSc.getlabel(dm, "marker")
@@ -536,6 +554,7 @@ for petsclib in PETSc.petsclibs
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, false, 1)
         PETSc.petsc_setname!(petsclib, fe, "u")
         PETSc.setfield!(dm, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         PETSc.createds!(dm)
 
         u = PETSc.dm_create_global_vec(dm)
@@ -557,6 +576,7 @@ for petsclib in PETSc.petsclibs
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 2, 1, true, 1)
         PETSc.petsc_setname!(petsclib, fe, "u")
         PETSc.setfield!(dm, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         PETSc.createds!(dm)
 
         u = PETSc.dm_create_global_vec(dm)
@@ -578,6 +598,7 @@ for petsclib in PETSc.petsclibs
         fe = PETSc.fe_create_lagrange(petsclib, _TC, 3, 1, false, 1)
         PETSc.petsc_setname!(petsclib, fe, "u3d")
         PETSc.setfield!(dm, 0, fe)
+        LibPETSc.PetscFEDestroy(petsclib, fe)
         PETSc.createds!(dm)
 
         # _dm_exact sums all coordinate components, works in any dimension.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ include("ts_ex16.jl")           # Regression test for the van der Pol IMEX examp
 include("low_level_is.jl")      # Low-level IS functions
 include("low_level_petscsection.jl")  # Low-level PetscSection functions
 include("low_level_tao.jl")     # Low-level Tao functions
+include("test_destroy.jl")      # destroy guards: stale cycle, double destroy
 
 include("testutils.jl")
 

--- a/test/test_destroy.jl
+++ b/test/test_destroy.jl
@@ -1,0 +1,88 @@
+# test/test_destroy.jl
+# Destroying PETSc objects must stay safe in the awkward cases: a second
+# explicit destroy, and an object left over from an earlier
+# initialize/finalize cycle.
+#
+# The stale-cycle case is the one that used to crash. `initialize` and
+# `finalize` each bump `petsclib.age`, and `PetscFinalize` frees the inner
+# communicator. An object created before that still holds a non-null pointer,
+# so without an age check `destroy` called `XXXDestroy` on a dead communicator
+# and PETSc aborted the process. Because leaked objects are destroyed by GC
+# finalizers, the abort landed at an arbitrary later point, typically inside
+# whichever test file happened to trigger a collection.
+
+using Test
+using PETSc
+using MPI
+
+if !Sys.iswindows()
+    MPI.Initialized() || MPI.Init()
+end
+
+@testset "destroy" begin
+
+for petsclib in PETSc.petsclibs
+    PetscScalar = PETSc.scalartype(petsclib)
+    PetscInt    = PETSc.inttype(petsclib)
+
+    @testset "$(PetscScalar)/$(PetscInt)" begin
+
+        # ── objects that outlive their initialize/finalize cycle ─────────────
+        @testset "stale cycle" begin
+            PETSc.initialize(petsclib)
+            v = PETSc.VecSeq(petsclib, PetscScalar[1, 2, 3, 4])
+            m = PETSc.MatSeqAIJ(petsclib, 4, 4, 1)
+            age_created = v.age
+            PETSc.finalize(petsclib)
+
+            # A new cycle: the library is live again, so a `finalized` check
+            # alone would wrongly conclude these are safe to destroy.
+            PETSc.initialize(petsclib)
+            @test PETSc.LibPETSc.getlib(typeof(petsclib)).age > age_created
+            @test !PETSc.isdestroyable(v, typeof(petsclib))
+            @test !PETSc.isdestroyable(m, typeof(petsclib))
+
+            # Must be a no-op rather than a call into the dead communicator.
+            @test PETSc.destroy(v) === nothing
+            @test PETSc.destroy(m) === nothing
+            @test v.ptr == C_NULL
+            @test m.ptr == C_NULL
+
+            PETSc.finalize(petsclib)
+        end
+
+        # ── ordinary lifetime, and destroying twice ──────────────────────────
+        @testset "double destroy" begin
+            PETSc.initialize(petsclib)
+
+            v = PETSc.VecSeq(petsclib, PetscScalar[1, 2, 3, 4])
+            @test PETSc.isdestroyable(v, typeof(petsclib))
+            PETSc.destroy(v)
+            @test v.ptr == C_NULL
+            @test !PETSc.isdestroyable(v, typeof(petsclib))
+            # The finalizer will reach this object again after the explicit
+            # destroy, so a repeat call has to stay harmless.
+            @test PETSc.destroy(v) === nothing
+
+            m = PETSc.MatSeqAIJ(petsclib, 4, 4, 1)
+            PETSc.destroy(m)
+            @test m.ptr == C_NULL
+            @test PETSc.destroy(m) === nothing
+
+            PETSc.finalize(petsclib)
+        end
+
+        # ── after the library is finalized ───────────────────────────────────
+        @testset "after finalize" begin
+            PETSc.initialize(petsclib)
+            v = PETSc.VecSeq(petsclib, PetscScalar[1, 2, 3, 4])
+            PETSc.finalize(petsclib)
+
+            @test !PETSc.isdestroyable(v, typeof(petsclib))
+            @test PETSc.destroy(v) === nothing
+        end
+
+    end # @testset "$(PetscScalar)/$(PetscInt)"
+end # for petsclib
+
+end # @testset "destroy"

--- a/test/test_destroy.jl
+++ b/test/test_destroy.jl
@@ -72,6 +72,24 @@ for petsclib in PETSc.petsclibs
             PETSc.finalize(petsclib)
         end
 
+        # ── objects built empty and filled in through an out-parameter ───────
+        # DMClone and friends take a pre-allocated object and write the pointer
+        # into it, so the object is built by the empty constructor rather than
+        # from a pointer. That path has to stamp the age too, or destroy
+        # silently skips the object and it leaks.
+        @testset "empty constructor stamps age" begin
+            PETSc.initialize(petsclib)
+            libage = PETSc.LibPETSc.getlib(typeof(petsclib)).age
+
+            for obj in (PETSc.LibPETSc.PetscDM(petsclib),
+                        PETSc.LibPETSc.PetscVec(petsclib),
+                        PETSc.LibPETSc.PetscMat(petsclib))
+                @test obj.age == libage
+            end
+
+            PETSc.finalize(petsclib)
+        end
+
         # ── after the library is finalized ───────────────────────────────────
         @testset "after finalize" begin
             PETSc.initialize(petsclib)

--- a/wrapping/prologue.jl
+++ b/wrapping/prologue.jl
@@ -58,7 +58,7 @@ mutable struct PetscVec{PetscLib} <: AbstractPetscVec{PetscLib}
 end
 
 # Convenience constructor from petsclib instance
-PetscVec(lib::PetscLib) where {PetscLib} = PetscVec{PetscLib}()
+PetscVec(lib::PetscLib) where {PetscLib} = PetscVec{PetscLib}(C_NULL, lib.age)
 PetscVec(ptr::CVec, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscVec{PetscLib}(ptr, age)
 Base.convert(::Type{CVec}, v::AbstractPetscVec) = v.ptr
 Base.unsafe_convert(::Type{CVec}, v::AbstractPetscVec) = v.ptr
@@ -79,7 +79,7 @@ mutable struct PetscMat{PetscLib} <: AbstractPetscMat{PetscLib}
 end
 
 # Convenience constructor from petsclib instance
-PetscMat(lib::PetscLib) where {PetscLib} = PetscMat{PetscLib}()
+PetscMat(lib::PetscLib) where {PetscLib} = PetscMat{PetscLib}(C_NULL, lib.age)
 PetscMat(ptr::CMat, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscMat{PetscLib}(ptr, age)
 Base.convert(::Type{CMat}, v::AbstractPetscMat) = v.ptr
 Base.unsafe_convert(::Type{CMat}, v::AbstractPetscMat) = v.ptr
@@ -100,7 +100,7 @@ mutable struct PetscKSP{PetscLib} <: AbstractPetscKSP{PetscLib}
 end
 
 # Convenience constructor from petsclib instance
-PetscKSP(lib::PetscLib) where {PetscLib} = PetscKSP{PetscLib}()
+PetscKSP(lib::PetscLib) where {PetscLib} = PetscKSP{PetscLib}(C_NULL, lib.age)
 PetscKSP(ptr::CKSP, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscKSP{PetscLib}(ptr, age)
 Base.convert(::Type{CKSP}, v::AbstractPetscKSP) = v.ptr
 Base.unsafe_convert(::Type{CKSP}, v::AbstractPetscKSP) = v.ptr
@@ -130,7 +130,7 @@ mutable struct PetscSNES{PetscLib} <: AbstractPetscSNES{PetscLib}
 end
 
 # Convenience constructor from petsclib instance
-PetscSNES(lib::PetscLib) where {PetscLib} = PetscSNES{PetscLib}()
+PetscSNES(lib::PetscLib) where {PetscLib} = PetscSNES{PetscLib}(C_NULL, lib.age)
 PetscSNES(ptr::Ptr, lib::PetscLib, f!::Function, updateJ!::Function, age::Int = lib.age) where {PetscLib} = PetscSNES{PetscLib}(ptr, age, f!, updateJ!)
 PetscSNES(ptr::Ptr, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscSNES{PetscLib}(ptr, age)
 Base.convert(::Type{CSNES}, v::AbstractPetscSNES) = v.ptr
@@ -152,7 +152,7 @@ mutable struct PetscDM{PetscLib} <: AbstractPetscDM{PetscLib}
 end
 
 # Convenience constructor from petsclib instance
-PetscDM(lib::PetscLib) where {PetscLib} = PetscDM{PetscLib}()
+PetscDM(lib::PetscLib) where {PetscLib} = PetscDM{PetscLib}(C_NULL, lib.age)
 PetscDM(ptr::CDM, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscDM{PetscLib}(ptr, age)
 Base.convert(::Type{CDM}, v::AbstractPetscDM) = v.ptr
 Base.unsafe_convert(::Type{CDM}, v::AbstractPetscDM) = v.ptr

--- a/wrapping/prologue.jl
+++ b/wrapping/prologue.jl
@@ -59,7 +59,7 @@ end
 
 # Convenience constructor from petsclib instance
 PetscVec(lib::PetscLib) where {PetscLib} = PetscVec{PetscLib}()
-PetscVec(ptr::CVec, lib::PetscLib, age::Int = 0) where {PetscLib} = PetscVec{PetscLib}(ptr, age)
+PetscVec(ptr::CVec, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscVec{PetscLib}(ptr, age)
 Base.convert(::Type{CVec}, v::AbstractPetscVec) = v.ptr
 Base.unsafe_convert(::Type{CVec}, v::AbstractPetscVec) = v.ptr
 # ------------------------------------------------------
@@ -80,7 +80,7 @@ end
 
 # Convenience constructor from petsclib instance
 PetscMat(lib::PetscLib) where {PetscLib} = PetscMat{PetscLib}()
-PetscMat(ptr::CMat, lib::PetscLib, age::Int = 0) where {PetscLib} = PetscMat{PetscLib}(ptr, age)
+PetscMat(ptr::CMat, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscMat{PetscLib}(ptr, age)
 Base.convert(::Type{CMat}, v::AbstractPetscMat) = v.ptr
 Base.unsafe_convert(::Type{CMat}, v::AbstractPetscMat) = v.ptr
 # ------------------------------------------------------
@@ -101,7 +101,7 @@ end
 
 # Convenience constructor from petsclib instance
 PetscKSP(lib::PetscLib) where {PetscLib} = PetscKSP{PetscLib}()
-PetscKSP(ptr::CKSP, lib::PetscLib, age::Int = 0) where {PetscLib} = PetscKSP{PetscLib}(ptr, age)
+PetscKSP(ptr::CKSP, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscKSP{PetscLib}(ptr, age)
 Base.convert(::Type{CKSP}, v::AbstractPetscKSP) = v.ptr
 Base.unsafe_convert(::Type{CKSP}, v::AbstractPetscKSP) = v.ptr
 
@@ -131,8 +131,8 @@ end
 
 # Convenience constructor from petsclib instance
 PetscSNES(lib::PetscLib) where {PetscLib} = PetscSNES{PetscLib}()
-PetscSNES(ptr::Ptr, lib::PetscLib, f!::Function, updateJ!::Function, age::Int = 0) where {PetscLib} = PetscSNES{PetscLib}(ptr, age, f!, updateJ!)
-PetscSNES(ptr::Ptr, lib::PetscLib, age::Int = 0) where {PetscLib} = PetscSNES{PetscLib}(ptr, age)
+PetscSNES(ptr::Ptr, lib::PetscLib, f!::Function, updateJ!::Function, age::Int = lib.age) where {PetscLib} = PetscSNES{PetscLib}(ptr, age, f!, updateJ!)
+PetscSNES(ptr::Ptr, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscSNES{PetscLib}(ptr, age)
 Base.convert(::Type{CSNES}, v::AbstractPetscSNES) = v.ptr
 Base.unsafe_convert(::Type{CSNES}, v::AbstractPetscSNES) = v.ptr
 # ------------------------------------------------------
@@ -153,7 +153,7 @@ end
 
 # Convenience constructor from petsclib instance
 PetscDM(lib::PetscLib) where {PetscLib} = PetscDM{PetscLib}()
-PetscDM(ptr::CDM, lib::PetscLib, age::Int = 0) where {PetscLib} = PetscDM{PetscLib}(ptr, age)
+PetscDM(ptr::CDM, lib::PetscLib, age::Int = lib.age) where {PetscLib} = PetscDM{PetscLib}(ptr, age)
 Base.convert(::Type{CDM}, v::AbstractPetscDM) = v.ptr
 Base.unsafe_convert(::Type{CDM}, v::AbstractPetscDM) = v.ptr
 # ------------------------------------------------------


### PR DESCRIPTION
Destroying a PETSc object created before an earlier `PETSc.finalize` segfaulted: `destroy` only checked `finalized(PetscLib)`, so an object from a previous cycle still looked live and `xxxDestroy` ran against a communicator that `PetscFinalize` had already freed. GC finalizers made the abort land at an arbitrary later point. 
Now, `destroy` goes through `isdestroyable` and every constructor stamps `lib.age` so it's checked properly.

Also some leak cleanup: `PetscFEDestroy` now correctly takes a pointer to the handle, and `test/dmplex.jl` releases the 23 FEs it created. `-objects_dump` reports a unfreed objects drop from 19650 to 0 :)
