### PR TITLE
Convert VecSeq lengths to the library's PetscInt

### DIFF
--- a/src/vec.jl
+++ b/src/vec.jl
@@ -59,7 +59,7 @@ VecPtr(::Type{PetscLib}, x...) where {PetscLib <: PetscLibType} = VecPtr(getlib(
 
 
 """
-    VecSeq(petsclib, n::Int)
+    VecSeq(petsclib, n::Integer)
 
 A standard, sequentially-stored serial PETSc vector for `petsclib.PetscScalar`
 of length `n`.
@@ -67,10 +67,11 @@ of length `n`.
 # External Links
 $(_doc_external("Vec/VecCreateSeq"))
 """
-function VecSeq(petsclib::PetscLib, n::Int) where {PetscLib <: PetscLibType}
+function VecSeq(petsclib::PetscLib, n::Integer) where {PetscLib <: PetscLibType}
     comm = MPI.COMM_SELF
     check_initialized(petsclib)
-    v = LibPETSc.VecCreateSeq(petsclib, comm, n)
+    PetscInt = petsclib.PetscInt
+    v = LibPETSc.VecCreateSeq(petsclib, comm, PetscInt(n))
     finalizer(destroy, v)
     return v
 end
@@ -595,8 +596,9 @@ Creates a sequential PETSc vector of length `n` given a julia array `array``
 """
 function VecSeq(petsclib::PetscLib, comm, x::Vector) where {PetscLib <: PetscLibType}
     check_initialized(petsclib)
-    
-    v = LibPETSc.VecCreateSeqWithArray(petsclib,comm, 1, length(x), x)    # solution vector
+    PetscInt = petsclib.PetscInt
+
+    v = LibPETSc.VecCreateSeqWithArray(petsclib, comm, PetscInt(1), PetscInt(length(x)), x)    # solution vector
     finalizer(destroy, v)
 
     return v

--- a/test/vec.jl
+++ b/test/vec.jl
@@ -162,6 +162,12 @@ end
     
         @test LibPETSc.VecGetType(petsclib, petsc_x) == "seq"
 
+        # The length can be a plain Julia Int whatever width the library uses
+        v = PETSc.VecSeq(petsclib, 10)
+        @test v !== nothing
+        @test LibPETSc.VecGetSize(petsclib, v) == 10
+        PETSc.destroy(v)
+
         PETSc.destroy(petsc_x)
         PETSc.finalize(petsclib)
     end


### PR DESCRIPTION
`VecSeq(petsclib, 10)` returns `nothing` on any library whose `PetscInt` isn't the platform `Int`, then fails at the finalizer with "objects of type Nothing cannot be finalized". The length was typed `::Int` and handed straight to the ccall, so it missed the generated method and landed on the empty stub at `Vec_wrappers.jl:4989`. Same for the `comm, x::Vector` method.

The array constructor just above already converts through `petsclib.PetscInt`, so these do too now. Hit it with `getlib(PetscScalar=Float64, PetscInt=Int32)`, or on 32-bit Julia where `Int` is `Int32`. The case added to the VecSeq testset errors without the fix.
