### PR TITLE
Fix two TS wrappers that took output parameters as inputs

### DIFF
--- a/src/autowrapped/TS_wrappers.jl
+++ b/src/autowrapped/TS_wrappers.jl
@@ -3640,7 +3640,7 @@ function TSSetEquationType(petsclib::PetscLibType, ts::TS, equation_type::TSEqua
 end 
 
 """
-	TSGetConvergedReason(petsclib::PetscLibType,ts::TS, reason::TSConvergedReason) 
+	reason::TSConvergedReason = TSGetConvergedReason(petsclib::PetscLibType,ts::TS) 
 Gets the reason the `TS` iteration was stopped.
 
 Not Collective
@@ -3659,9 +3659,10 @@ Level: beginner
 # External Links
 $(_doc_external("Ts/TSGetConvergedReason"))
 """
-function TSGetConvergedReason(petsclib::PetscLibType, ts::TS, reason::TSConvergedReason) end
+function TSGetConvergedReason(petsclib::PetscLibType, ts::TS) end
 
-@for_petsc function TSGetConvergedReason(petsclib::$UnionPetscLib, ts::TS, reason::TSConvergedReason )
+@for_petsc function TSGetConvergedReason(petsclib::$UnionPetscLib, ts::TS)
+	reason = Ref{TSConvergedReason}()
 
     @chk ccall(
                (:TSGetConvergedReason, $petsc_library),
@@ -3671,7 +3672,7 @@ function TSGetConvergedReason(petsclib::PetscLibType, ts::TS, reason::TSConverge
               )
 
 
-	return nothing
+	return reason[]
 end 
 
 """

--- a/src/autowrapped/TS_wrappers.jl
+++ b/src/autowrapped/TS_wrappers.jl
@@ -4069,7 +4069,7 @@ function TSSetTolerances(petsclib::PetscLibType, ts::TS, atol::PetscReal, vatol:
 end 
 
 """
-	atol::PetscReal,rtol::PetscReal = TSGetTolerances(petsclib::PetscLibType,ts::TS, vatol::PetscVec, vrtol::PetscVec) 
+	atol::PetscReal,vatol::PetscVec,rtol::PetscReal,vrtol::PetscVec = TSGetTolerances(petsclib::PetscLibType,ts::TS) 
 Get tolerances for local truncation error when using adaptive controller
 
 Logically Collective
@@ -4090,13 +4090,13 @@ Level: beginner
 # External Links
 $(_doc_external("Ts/TSGetTolerances"))
 """
-function TSGetTolerances(petsclib::PetscLibType, ts::TS, vatol::PetscVec, vrtol::PetscVec) end
+function TSGetTolerances(petsclib::PetscLibType, ts::TS) end
 
-@for_petsc function TSGetTolerances(petsclib::$UnionPetscLib, ts::TS, vatol::PetscVec, vrtol::PetscVec )
+@for_petsc function TSGetTolerances(petsclib::$UnionPetscLib, ts::TS)
 	atol_ = Ref{$PetscReal}()
-	vatol_ = Ref(vatol.ptr)
+	vatol_ = Ref{CVec}(C_NULL)
 	rtol_ = Ref{$PetscReal}()
-	vrtol_ = Ref(vrtol.ptr)
+	vrtol_ = Ref{CVec}(C_NULL)
 
     @chk ccall(
                (:TSGetTolerances, $petsc_library),
@@ -4105,12 +4105,12 @@ function TSGetTolerances(petsclib::PetscLibType, ts::TS, vatol::PetscVec, vrtol:
                ts, atol_, vatol_, rtol_, vrtol_,
               )
 
-	atol = atol_[]
-	vatol.ptr = C_NULL
-	rtol = rtol_[]
-	vrtol.ptr = C_NULL
+	# The per-component vectors belong to the TS, so they get no finalizer.
+	# They come back NULL when only scalar tolerances are set.
+	vatol = PetscVec(vatol_[], petsclib)
+	vrtol = PetscVec(vrtol_[], petsclib)
 
-	return atol,rtol
+	return atol_[],vatol,rtol_[],vrtol
 end 
 
 """

--- a/test/low_level_ts.jl
+++ b/test/low_level_ts.jl
@@ -61,6 +61,17 @@ using MPI
             PETSc.LibPETSc.TSDestroy(petsclib, ts)
         end
     end
-    
+
+    # TSGetConvergedReason writes through an out-parameter. Wrapped as an input
+    # it was uncallable, since there was no way to read the value back.
+    @testset "TS converged reason" begin
+        ts = PETSc.LibPETSc.TSCreate(petsclib, test_comm)
+        reason = PETSc.LibPETSc.TSGetConvergedReason(petsclib, ts)
+        @test reason isa PETSc.LibPETSc.TSConvergedReason
+        # Nothing has been solved yet, so the TS is still iterating.
+        @test reason == PETSc.LibPETSc.TS_CONVERGED_ITERATING
+        PETSc.LibPETSc.TSDestroy(petsclib, ts)
+    end
+
     PETSc.finalize(petsclib)
 end

--- a/test/low_level_ts.jl
+++ b/test/low_level_ts.jl
@@ -73,5 +73,35 @@ using MPI
         PETSc.LibPETSc.TSDestroy(petsclib, ts)
     end
 
+    # TSGetTolerances has four outputs. Taking two of them as inputs meant the
+    # vectors could not be read back, and the wrapper nulled the caller's
+    # handles on the way out, losing the reference to a live PETSc object.
+    @testset "TS tolerances" begin
+        PetscScalar = PETSc.scalartype(petsclib)
+        ts = PETSc.LibPETSc.TSCreate(petsclib, test_comm)
+
+        # A NULL vector tells PETSc to use the scalar tolerance.
+        null_vec = PETSc.LibPETSc.PetscVec(petsclib)
+        PETSc.LibPETSc.TSSetTolerances(petsclib, ts, 1e-8, null_vec, 1e-6, null_vec)
+
+        atol, vatol, rtol, vrtol = PETSc.LibPETSc.TSGetTolerances(petsclib, ts)
+        @test atol == 1e-8
+        @test rtol == 1e-6
+        @test vatol isa PETSc.LibPETSc.PetscVec
+        @test vatol.ptr == C_NULL
+        @test vrtol.ptr == C_NULL
+
+        # With per-component tolerances the vectors come back, and the handle
+        # passed to the setter stays valid.
+        v = PETSc.VecSeq(petsclib, PetscScalar[1e-9, 1e-9, 1e-9])
+        PETSc.LibPETSc.TSSetTolerances(petsclib, ts, 1e-8, v, 1e-6, v)
+        _, vatol2, _, _ = PETSc.LibPETSc.TSGetTolerances(petsclib, ts)
+        @test v.ptr != C_NULL
+        @test vatol2.ptr == v.ptr
+
+        PETSc.destroy(v)
+        PETSc.LibPETSc.TSDestroy(petsclib, ts)
+    end
+
     PETSc.finalize(petsclib)
 end


### PR DESCRIPTION
`TSGetConvergedReason` and `TSGetTolerances` wrapped PETSc output parameters as Julia inputs. The first had no way to return the reason at all. The second returned only the two scalars, and set the caller's `vatol.ptr` and `vrtol.ptr` to `C_NULL` on the way out, dropping the only Julia reference to vectors PETSc still owned. Both now take just `(petsclib, ts)` and return their outputs.

This should close issue #247.

Note: the issue can be find all over the whole `src/autowrapped` and is therefore wider than these two cases. The durable fix lies somewhere in the generator's output-parameter detection. 