### PR TITLE
High-level interface for TS object

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -43,6 +43,7 @@ julia = "^1.10"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -51,4 +52,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["ForwardDiff", "UnicodePlots", "Test", "Plots", "SparseDiffTools", "Printf", "Random", "CairoMakie", "KernelAbstractions"]
+test = ["ForwardDiff", "UnicodePlots", "Test", "Plots", "SparseDiffTools", "Printf", "Random", "CairoMakie", "KernelAbstractions", "Logging"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,6 +23,7 @@ makedocs(;
             "DMPlex" =>  "man/dmplex.md",
             "KSP" =>  "man/ksp.md",
             "SNES" =>  "man/snes.md",
+            "TS" =>  "man/ts.md",
         ],
         "Low-level interface (LibPETSc)" => Any[
             "Introduction" =>  "man/lowlevel_intro.md",

--- a/docs/src/man/ts.md
+++ b/docs/src/man/ts.md
@@ -101,6 +101,18 @@ Each may return a PETSc error code; any other return value counts as success.
 
 A callback that raises a Julia exception is reported and turned into a PETSc failure rather than being allowed to escape into C, where it would take the process down with it. The error is logged with its backtrace and [`PETSc.solve!`](@ref) then raises a `PetscError`.
 
+### Precompilation
+
+Each setter builds its `@cfunction` trampoline when you call it, so nothing here is affected by precompilation, and there is nothing you need to do about it.
+
+It is worth knowing where the hazard is, though, because the low-level examples show the other pattern. A `@cfunction` yields a pointer valid only for the session that evaluated it, so this at the top level of a package:
+
+```julia
+const MY_RHS_PTR = @cfunction(my_rhs!, PetscErrorCode, (CTS, PetscReal, CVec, CVec, Ptr{Cvoid}))
+```
+
+captures a pointer during precompilation and hands PETSc a stale one in every later session. In a script such as `examples/ex16.jl` it is fine, since the file is evaluated afresh each run. Inside a package it is not: build the pointer inside the function that registers it, or assign it from `__init__`.
+
 ## Passing your own data
 
 Anything stored with [`PETSc.set_user_ctx!`](@ref) is handed back as a trailing argument, to whichever callbacks have a method that accepts one:

--- a/docs/src/man/ts.md
+++ b/docs/src/man/ts.md
@@ -1,0 +1,161 @@
+# TS
+
+The TS (Time Stepping) module integrates ordinary differential equations and differential algebraic equations in time, and is the layer PETSc builds its implicit, explicit and IMEX methods on.
+
+The interface described here is the high-level one. It owns the `@cfunction` trampolines, keeps your callbacks rooted for as long as the stepper lives, and frees the object for you on a sequential communicator. The [low-level TS bindings](ts_lowlevel.md) remain available and unchanged.
+
+## Overview
+
+A problem is given to TS in one of two forms, or in both at once:
+
+- **Explicit**, ``du/dt = G(t, u)``, through [`PETSc.set_rhs_function!`](@ref) and optionally [`PETSc.set_rhs_jacobian!`](@ref).
+- **Implicit**, ``F(t, u, du/dt) = 0``, through [`PETSc.set_ifunction!`](@ref) and [`PETSc.set_ijacobian!`](@ref). This form also covers a DAE and a problem with a mass matrix.
+
+Setting both is how an IMEX method splits a problem into the stiff part it treats implicitly and the rest it treats explicitly.
+
+## Creating a stepper
+
+```julia
+ts = PETSc.TS(petsclib, MPI.COMM_WORLD)
+
+# or with options, which are applied when you call solve!
+ts = PETSc.TS(petsclib, MPI.COMM_WORLD;
+    ts_type = "bdf",
+    ts_adapt_type = "basic",
+)
+```
+
+Options given here are held and applied inside [`PETSc.solve!`](@ref) rather than at construction, so a DM and the callbacks attached afterwards are in place before PETSc reads them. Until then the object has no type, and [`PETSc.type`](@ref) answers `nothing`.
+
+On a communicator of size 1 the garbage collector calls [`PETSc.destroy!`](@ref). On a larger one, destruction is yours to do, since collection is asynchronous and the call is collective.
+
+## An explicit problem
+
+Solving ``du/dt = -u`` from ``u(0) = 1``:
+
+```julia
+ts = PETSc.TS(petsclib, MPI.COMM_SELF)
+PETSc.set_type!(ts, :rk)
+
+u = PETSc.VecSeq(petsclib, 1)
+u[1] = 1.0
+PETSc.assemble!(u)
+
+PETSc.set_rhs_function!(ts) do F, ts, t, u
+    PETSc.withlocalarray!((u, F); read = (true, false), write = (false, true)) do ua, Fa
+        Fa[1] = -ua[1]
+    end
+    return 0
+end
+
+PETSc.set_time!(ts, 0.0)
+PETSc.set_timestep!(ts, 0.01)
+PETSc.set_max_time!(ts, 1.0)
+
+PETSc.solve!(u, ts)
+```
+
+The callback comes first in the argument list, so `do` block syntax works. Pass it in the other order, `set_rhs_function!(ts, f!)`, when it is already a value.
+
+## An implicit problem
+
+The same equation written as ``F(t, u, u_t) = u_t + u = 0``, stepped with backward Euler. The Jacobian asked for is $\partial F/\partial u + \sigma\, \partial F/\partial u_t$, where PETSc supplies the shift ``\sigma``:
+
+```julia
+ts = PETSc.TS(petsclib, MPI.COMM_SELF)
+PETSc.set_type!(ts, :beuler)
+
+J = PETSc.MatSeqAIJ(petsclib, 1, 1, petsclib.PetscInt(1))
+
+PETSc.set_ifunction!(ts) do F, ts, t, u, u_t
+    PETSc.withlocalarray!(
+        (u, u_t, F);
+        read = (true, true, false),
+        write = (false, false, true),
+    ) do ua, uta, Fa
+        Fa[1] = uta[1] + ua[1]
+    end
+    return 0
+end
+
+PETSc.set_ijacobian!(ts, J) do A, P, ts, t, u, u_t, shift
+    A[1, 1] = shift + 1
+    PETSc.assemble!(A)
+    return 0
+end
+```
+
+A Jacobian callback is always handed both the Jacobian `A` and the preconditioning matrix `P`. They are the same object unless you passed two, which is worth testing with `A.ptr == P.ptr` before filling `P` a second time.
+
+## Callback signatures
+
+| Setter | Callback |
+| --- | --- |
+| [`PETSc.set_rhs_function!`](@ref) | `f!(F, ts, t, u)` |
+| [`PETSc.set_rhs_jacobian!`](@ref) | `updateJ!(A, P, ts, t, u)` |
+| [`PETSc.set_ifunction!`](@ref) | `f!(F, ts, t, u, u_t)` |
+| [`PETSc.set_ijacobian!`](@ref) | `updateJ!(A, P, ts, t, u, u_t, shift)` |
+| [`PETSc.set_monitor!`](@ref) | `f(ts, step, t, u)` |
+
+Each may return a PETSc error code; any other return value counts as success.
+
+A callback that raises a Julia exception is reported and turned into a PETSc failure rather than being allowed to escape into C, where it would take the process down with it. The error is logged with its backtrace and [`PETSc.solve!`](@ref) then raises a `PetscError`.
+
+## Passing your own data
+
+Anything stored with [`PETSc.set_user_ctx!`](@ref) is handed back as a trailing argument, to whichever callbacks have a method that accepts one:
+
+```julia
+PETSc.set_user_ctx!(ts, (; viscosity = 1e-3))
+
+PETSc.set_rhs_function!(ts) do F, ts, t, u, ctx
+    # ctx.viscosity is available here
+    return 0
+end
+```
+
+The object is held on the Julia side by `ts`, so it stays alive without any pinning of your own.
+
+## Watching a solve
+
+```julia
+PETSc.set_monitor!(ts) do ts, step, t, u
+    @printf("step %3d  t = %.4f\n", step, t)
+    return 0
+end
+```
+
+The monitor runs once before the first step and once after each accepted one.
+It does not replace the monitors PETSc installs from the options database, such as `-ts_monitor`.
+
+## Solving, and reading the result
+
+```julia
+PETSc.solve!(u, ts)          # integrate, starting from u
+PETSc.solve!(ts)             # or from the vector already set on ts
+
+PETSc.converged_reason(ts)   # why it stopped
+PETSc.solve_time(ts)         # the time actually reached
+PETSc.step_number(ts)        # steps taken
+PETSc.snes_iterations(ts)    # nonlinear iterations, summed over the steps
+```
+
+The final step lands exactly on [`PETSc.set_max_time!`](@ref) by default. 
+This differs from PETSc, whose own default, `TS_EXACTFINALTIME_UNSPECIFIED`, integrates past the requested time without saying so; pass `exact_final_time` to the constructor or call [`PETSc.set_exact_final_time!`](@ref) to choose otherwise.
+
+For finer control, [`PETSc.step!`](@ref) takes a single step and [`PETSc.interpolate!`](@ref) samples the solution inside the step just taken.
+
+## Cleaning up
+
+```julia
+PETSc.destroy!(ts)
+```
+
+Safe to call more than once, and a no-op on a handle left over from a previous initialize/finalize cycle. `PETSc.destroy` also works, for consistency with the rest of the package.
+
+## Functions
+
+```@autodocs
+Modules = [PETSc]
+Pages   = ["ts.jl"]
+```

--- a/docs/src/man/ts_lowlevel.md
+++ b/docs/src/man/ts_lowlevel.md
@@ -118,3 +118,10 @@ Modules = [PETSc.LibPETSc]
 Pages   = ["autowrapped/TSaddons_wrappers.jl"]
 Order   = [:function]
 ```
+
+## Hand-written overloads
+
+Some `LibPETSc.TS*` methods are written by hand in `src/ts.jl` rather than generated. 
+They take a raw `@cfunction` pointer where the generated binding expects PETSc's own function-wrapper type,  or they return a value the generated binding takes as an argument and overwrites (e.g., `TSGetSolution`, `TSGetSNES` and `TSGetKSP`).
+
+Their docstrings are written inside the `PETSc` module, so they are listed with the rest of `src/ts.jl` on the [high-level TS page](ts.md).

--- a/src/autowrapped/petsc_library.jl
+++ b/src/autowrapped/petsc_library.jl
@@ -236,14 +236,43 @@ const CTS = Ptr{Cvoid}
 abstract type AbstractTS{T} end
 
 mutable struct TS{PetscLib} <: AbstractTS{PetscLib}
-    ptr::Ptr{Cvoid}
-    
-    TS{PetscLib}(ptr::Ptr{Cvoid} = C_NULL) where {PetscLib} = new{PetscLib}(ptr)
+    ptr::CTS
+    age::Int
+    rhs_function!::Function
+    rhs_jacobian!::Function
+    ifunction!::Function
+    ijacobian!::Function
+    monitor::Function
+    user_ctx::Any
+    opts::Any
+
+    TS{PetscLib}(
+        ptr::CTS = C_NULL,
+        age::Int = 0,
+        rhs_function!::Function = _ -> error("rhs_function! not defined"),
+        rhs_jacobian!::Function = _ -> error("rhs_jacobian! not defined"),
+        ifunction!::Function = _ -> error("ifunction! not defined"),
+        ijacobian!::Function = _ -> error("ijacobian! not defined"),
+        monitor::Function = _ -> error("monitor not defined"),
+        user_ctx::Any = nothing,
+        opts::Any = nothing,
+    ) where {PetscLib} = new{PetscLib}(
+        ptr,
+        age,
+        rhs_function!,
+        rhs_jacobian!,
+        ifunction!,
+        ijacobian!,
+        monitor,
+        user_ctx,
+        opts,
+    )
 end
 
 # Convenience constructors
-TS(lib::PetscLib) where {PetscLib} = TS{PetscLib}()
-TS(ptr::Ptr{Cvoid}, lib::PetscLib) where {PetscLib} = TS{PetscLib}(ptr)
+TS(lib::PetscLib) where {PetscLib} = TS{PetscLib}(C_NULL, lib.age)
+TS(ptr::CTS, lib::PetscLib, age::Int = lib.age) where {PetscLib} =
+    TS{PetscLib}(ptr, age)
 
 # Conversion methods
 Base.convert(::Type{Ptr{Cvoid}}, v::AbstractTS) = v.ptr

--- a/src/ts.jl
+++ b/src/ts.jl
@@ -375,3 +375,1164 @@ LibPETSc.@for_petsc function LibPETSc.TSARKIMEXRegister(
     )
     return nothing
 end
+
+# ============================================================================
+#   High-level TS interface
+# ============================================================================
+
+import .LibPETSc:
+    AbstractTS, CTS, TS, AbstractPetscDM, AbstractPetscVec, PetscVec, CVec
+
+function Base.show(io::IO, ts::AbstractTS{PetscLib}) where {PetscLib}
+    if ts.ptr == C_NULL
+        print(io, "PETSc TS (null pointer)")
+    else
+        print(io, "PETSc TS object")
+    end
+    return nothing
+end
+
+"""
+    TS(petsclib, comm::MPI.Comm; prefix = "", options...)
+
+Create a PETSc time stepper on the communicator `comm`.
+
+Options are stored and applied in [`solve!`](@ref) rather than here, so that a
+DM and callbacks attached after construction are visible to `TSSetFromOptions`.
+
+`exact_final_time` defaults to `TS_EXACTFINALTIME_MATCHSTEP`, so the last step
+lands on the time set by [`set_max_time!`](@ref). 
+PETSc's own default is `TS_EXACTFINALTIME_UNSPECIFIED`, which integrates 
+to the wrong time without reporting an error.
+
+If `comm` has size 1 the garbage collector calls [`destroy!`](@ref).
+Otherwise destruction is the caller's responsibility.
+
+# External Links
+$(_doc_external("TS/TSCreate"))
+$(_doc_external("TS/TSSetExactFinalTime"))
+"""
+function TS(
+    petsclib::PetscLib,
+    comm::MPI.Comm;
+    prefix::String = "",
+    exact_final_time::LibPETSc.TSExactFinalTimeOption = LibPETSc.TS_EXACTFINALTIME_MATCHSTEP,
+    options...,
+) where {PetscLib}
+    check_initialized(getlib(PetscLib))
+
+    petsclib = getlib(PetscLib)
+    ts = LibPETSc.TSCreate(petsclib, comm)
+
+    if !isempty(prefix)
+        LibPETSc.TSSetOptionsPrefix(petsclib, ts, prefix)
+    end
+
+    LibPETSc.TSSetExactFinalTime(petsclib, ts, exact_final_time)
+
+    if !isempty(options)
+        ts.opts = Options(petsclib; options...)
+    end
+
+    if MPI.Comm_size(comm) == 1
+        finalizer(destroy!, ts)
+    end
+
+    return ts
+end
+
+"""
+    set_exact_final_time!(ts::AbstractTS, option)
+
+Choose how the final step meets the time set by [`set_max_time!`](@ref):
+`TS_EXACTFINALTIME_MATCHSTEP`, `TS_EXACTFINALTIME_INTERPOLATE` or `TS_EXACTFINALTIME_STEPOVER`.
+
+# External Links
+$(_doc_external("TS/TSSetExactFinalTime"))
+"""
+function set_exact_final_time!(
+    ts::AbstractTS{PetscLib},
+    option::LibPETSc.TSExactFinalTimeOption,
+) where {PetscLib}
+    LibPETSc.TSSetExactFinalTime(getlib(PetscLib), ts, option)
+    return nothing
+end
+
+"""
+    set_adapt_type!(ts::AbstractTS, type::Symbol)
+
+Set the timestep adaptivity controller, for example `:none` to hold the step size fixed, 
+or `:basic` for the default error-based controller.
+
+# External Links
+$(_doc_external("TS/TSAdaptSetType"))
+"""
+function set_adapt_type!(ts::AbstractTS{PetscLib}, type::Symbol) where {PetscLib}
+    petsclib = getlib(PetscLib)
+    LibPETSc.TSAdaptSetType(
+        petsclib,
+        LibPETSc.TSGetAdapt(petsclib, ts),
+        String(type),
+    )
+    return nothing
+end
+
+"""
+    destroy!(ts::AbstractTS)
+
+Destroy `ts` and release the options database attached to it.
+
+The call is a no-op when the library has been finalized or when `ts` predates
+the current initialize/finalize cycle, so a stale handle never reaches `TSDestroy`.
+
+# External Links
+$(_doc_external("TS/TSDestroy"))
+"""
+function destroy!(ts::AbstractTS{PetscLib}) where {PetscLib}
+    if !isnothing(ts.opts)
+        destroy(ts.opts)
+        ts.opts = nothing
+    end
+    if isdestroyable(ts, PetscLib)
+        LibPETSc.TSDestroy(PetscLib, ts)
+    end
+    ts.ptr = C_NULL
+    return nothing
+end
+
+"""
+    destroy(ts::AbstractTS)
+
+Destroy `ts`. Provided so that the spelling used by the rest of the package keeps working; 
+[`destroy!`](@ref) is the name to prefer, since the call mutates `ts`.
+
+# External Links
+$(_doc_external("TS/TSDestroy"))
+"""
+destroy(ts::AbstractTS) = destroy!(ts)
+
+"""
+    comm(ts::AbstractTS)
+
+The MPI communicator `ts` was built on.
+
+# External Links
+$(_doc_external("Sys/PetscObjectGetComm"))
+"""
+comm(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.PetscObjectGetComm(PetscLib, ts)
+
+"""
+    type(ts::AbstractTS)
+
+The time-stepping method currently set on `ts`, as a `Symbol`, or `nothing` when none has been set yet.
+
+PETSc reports an unset type as a null string, which the generated `TSGetType` cannot convert. 
+Asking a freshly created stepper for its type is reasonable, so it is answered with `nothing` here.
+
+# External Links
+$(_doc_external("TS/TSGetType"))
+"""
+function type end
+
+LibPETSc.@for_petsc function type(ts::AbstractTS{$PetscLib})
+    r_type = Ref{Ptr{Cchar}}(C_NULL)
+    LibPETSc.@chk ccall(
+        (:TSGetType, $petsc_library),
+        LibPETSc.PetscErrorCode,
+        (LibPETSc.CTS, Ptr{Ptr{Cchar}}),
+        ts,
+        r_type,
+    )
+    return r_type[] == C_NULL ? nothing : Symbol(unsafe_string(r_type[]))
+end
+
+"""
+    set_type!(ts::AbstractTS, type::Symbol)
+
+Set the time-stepping method, for example `:bdf`, `:rk` or `:arkimex`.
+
+# External Links
+$(_doc_external("TS/TSSetType"))
+"""
+function set_type!(ts::AbstractTS{PetscLib}, type::Symbol) where {PetscLib}
+    LibPETSc.TSSetType(getlib(PetscLib), ts, String(type))
+    return nothing
+end
+
+"""
+    set_problem_type!(ts::AbstractTS, type)
+
+Declare the problem as `LibPETSc.TS_LINEAR` or `LibPETSc.TS_NONLINEAR`.
+
+# External Links
+$(_doc_external("TS/TSSetProblemType"))
+"""
+function set_problem_type!(
+    ts::AbstractTS{PetscLib},
+    type::LibPETSc.TSProblemType,
+) where {PetscLib}
+    LibPETSc.TSSetProblemType(getlib(PetscLib), ts, type)
+    return nothing
+end
+
+"""
+    dm(ts::AbstractTS)
+
+The DM attached to `ts`. The DM is owned by `ts`.
+
+# External Links
+$(_doc_external("TS/TSGetDM"))
+"""
+dm(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetDM(getlib(PetscLib), ts)
+
+"""
+    set_dm!(ts::AbstractTS, dm::AbstractPetscDM)
+
+Attach `dm` to `ts`.
+
+# External Links
+$(_doc_external("TS/TSSetDM"))
+"""
+function set_dm!(
+    ts::AbstractTS{PetscLib},
+    dm::AbstractPetscDM{PetscLib},
+) where {PetscLib}
+    LibPETSc.TSSetDM(getlib(PetscLib), ts, dm)
+    return nothing
+end
+
+"""
+    TSGetSolution(petsclib, ts)
+
+Return the solution vector held by `ts`.
+
+The generated three-argument form takes the vector as an input and nulls 
+the caller's handle, so it cannot be used to read the solution back. 
+The vector is owned by `ts` and must not be destroyed.
+
+# External Links
+$(_doc_external("TS/TSGetSolution"))
+"""
+function LibPETSc.TSGetSolution(petsclib::LibPETSc.PetscLibType, ts::TS) end
+
+LibPETSc.@for_petsc function LibPETSc.TSGetSolution(
+    petsclib::$UnionPetscLib,
+    ts::TS,
+)
+    v_ = Ref{CVec}(C_NULL)
+    LibPETSc.@chk ccall(
+        (:TSGetSolution, $petsc_library),
+        LibPETSc.PetscErrorCode,
+        (CTS, Ptr{CVec}),
+        ts,
+        v_,
+    )
+    return PetscVec(v_[], petsclib)
+end
+
+"""
+    solution(ts::AbstractTS)
+
+The solution vector held by `ts`. It is owned by `ts`, so do not destroy it.
+
+# External Links
+$(_doc_external("TS/TSGetSolution"))
+"""
+solution(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetSolution(getlib(PetscLib), ts)
+
+"""
+    set_solution!(ts::AbstractTS, u::AbstractPetscVec)
+
+Set the initial condition of `ts`.
+
+# External Links
+$(_doc_external("TS/TSSetSolution"))
+"""
+function set_solution!(
+    ts::AbstractTS{PetscLib},
+    u::AbstractPetscVec{PetscLib},
+) where {PetscLib}
+    LibPETSc.TSSetSolution(getlib(PetscLib), ts, u)
+    return nothing
+end
+
+# Time and step controls
+# ----------------------------------------------------------------------------
+
+"""
+    current_time(ts::AbstractTS)
+
+The time `ts` has reached.
+
+# External Links
+$(_doc_external("TS/TSGetTime"))
+"""
+current_time(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetTime(getlib(PetscLib), ts)
+
+"""
+    set_time!(ts::AbstractTS, t)
+
+Set the current time of `ts`.
+
+# External Links
+$(_doc_external("TS/TSSetTime"))
+"""
+function set_time!(ts::AbstractTS{PetscLib}, t) where {PetscLib}
+    LibPETSc.TSSetTime(getlib(PetscLib), ts, PetscLib.PetscReal(t))
+    return nothing
+end
+
+"""
+    timestep(ts::AbstractTS)
+
+The current step size.
+
+# External Links
+$(_doc_external("TS/TSGetTimeStep"))
+"""
+timestep(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetTimeStep(getlib(PetscLib), ts)
+
+"""
+    set_timestep!(ts::AbstractTS, dt)
+
+Set the step size.
+
+# External Links
+$(_doc_external("TS/TSSetTimeStep"))
+"""
+function set_timestep!(ts::AbstractTS{PetscLib}, dt) where {PetscLib}
+    LibPETSc.TSSetTimeStep(getlib(PetscLib), ts, PetscLib.PetscReal(dt))
+    return nothing
+end
+
+"""
+    max_time(ts::AbstractTS)
+
+The time at which integration stops.
+
+# External Links
+$(_doc_external("TS/TSGetMaxTime"))
+"""
+max_time(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetMaxTime(getlib(PetscLib), ts)
+
+"""
+    set_max_time!(ts::AbstractTS, t)
+
+Set the time at which integration stops.
+
+# External Links
+$(_doc_external("TS/TSSetMaxTime"))
+"""
+function set_max_time!(ts::AbstractTS{PetscLib}, t) where {PetscLib}
+    LibPETSc.TSSetMaxTime(getlib(PetscLib), ts, PetscLib.PetscReal(t))
+    return nothing
+end
+
+"""
+    max_steps(ts::AbstractTS)
+
+The step count at which integration stops.
+
+# External Links
+$(_doc_external("TS/TSGetMaxSteps"))
+"""
+max_steps(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetMaxSteps(getlib(PetscLib), ts)
+
+"""
+    set_max_steps!(ts::AbstractTS, n)
+
+Set the step count at which integration stops.
+
+# External Links
+$(_doc_external("TS/TSSetMaxSteps"))
+"""
+function set_max_steps!(ts::AbstractTS{PetscLib}, n) where {PetscLib}
+    LibPETSc.TSSetMaxSteps(getlib(PetscLib), ts, PetscLib.PetscInt(n))
+    return nothing
+end
+
+"""
+    step_number(ts::AbstractTS)
+
+The number of steps taken so far.
+
+# External Links
+$(_doc_external("TS/TSGetStepNumber"))
+"""
+step_number(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetStepNumber(getlib(PetscLib), ts)
+
+"""
+    tolerances(ts::AbstractTS)
+
+Local truncation error tolerances, as `(; atol, rtol, vatol, vrtol)`.
+
+`vatol` and `vrtol` hold per-component tolerances and carry a null pointer when
+only the scalar tolerances are set. Both are owned by `ts`.
+
+# External Links
+$(_doc_external("TS/TSGetTolerances"))
+"""
+function tolerances(ts::AbstractTS{PetscLib}) where {PetscLib}
+    atol, vatol, rtol, vrtol = LibPETSc.TSGetTolerances(getlib(PetscLib), ts)
+    return (; atol, rtol, vatol, vrtol)
+end
+
+"""
+    set_tolerances!(ts::AbstractTS; atol, rtol, vatol, vrtol)
+
+Set the local truncation error tolerances.
+
+Pass `vatol` or `vrtol` to give per-component tolerances; 
+leaving them at `nothing` selects the scalar tolerance.
+
+# External Links
+$(_doc_external("TS/TSSetTolerances"))
+"""
+function set_tolerances!(
+    ts::AbstractTS{PetscLib};
+    atol = 1e-8,
+    rtol = 1e-6,
+    vatol::Union{Nothing, AbstractPetscVec{PetscLib}} = nothing,
+    vrtol::Union{Nothing, AbstractPetscVec{PetscLib}} = nothing,
+) where {PetscLib}
+    petsclib = getlib(PetscLib)
+    PetscReal = PetscLib.PetscReal
+    null_vec = LibPETSc.PetscVec(petsclib)
+    LibPETSc.TSSetTolerances(
+        petsclib,
+        ts,
+        PetscReal(atol),
+        isnothing(vatol) ? null_vec : vatol,
+        PetscReal(rtol),
+        isnothing(vrtol) ? null_vec : vrtol,
+    )
+    return nothing
+end
+
+"""
+    converged_reason(ts::AbstractTS)
+
+Why the integration stopped, as a `LibPETSc.TSConvergedReason`.
+
+# External Links
+$(_doc_external("TS/TSGetConvergedReason"))
+"""
+converged_reason(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetConvergedReason(getlib(PetscLib), ts)
+
+"""
+    solve_time(ts::AbstractTS)
+
+The time reached by the last [`solve!`](@ref).
+
+This is the time the integration actually stopped at, which is not the time
+asked for by [`set_max_time!`](@ref) unless the final step was made to land on it; 
+see [`set_exact_final_time!`](@ref).
+
+# External Links
+$(_doc_external("TS/TSGetSolveTime"))
+"""
+solve_time(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetSolveTime(getlib(PetscLib), ts)
+
+"""
+    snes_iterations(ts::AbstractTS)
+
+Total number of nonlinear iterations taken so far, summed over the steps.
+
+# External Links
+$(_doc_external("TS/TSGetSNESIterations"))
+"""
+snes_iterations(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetSNESIterations(getlib(PetscLib), ts)
+
+"""
+    ksp_iterations(ts::AbstractTS)
+
+Total number of linear iterations taken so far, summed over the steps.
+
+# External Links
+$(_doc_external("TS/TSGetKSPIterations"))
+"""
+ksp_iterations(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetKSPIterations(getlib(PetscLib), ts)
+
+"""
+    step_rejections(ts::AbstractTS)
+
+Number of steps the adaptivity controller has rejected.
+
+# External Links
+$(_doc_external("TS/TSGetStepRejections"))
+"""
+step_rejections(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetStepRejections(getlib(PetscLib), ts)
+
+"""
+    snes_failures(ts::AbstractTS)
+
+Number of failed nonlinear solves.
+
+# External Links
+$(_doc_external("TS/TSGetSNESFailures"))
+"""
+snes_failures(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetSNESFailures(getlib(PetscLib), ts)
+
+"""
+    TSGetSNES(petsclib, ts)
+
+Return the nonlinear solver held by `ts`.
+
+The generated three-argument form takes the solver as an input and nulls the
+caller's handle, so it cannot be used to read the solver back. 
+The `SNES` is owned by `ts` and must not be destroyed.
+
+# External Links
+$(_doc_external("TS/TSGetSNES"))
+"""
+function LibPETSc.TSGetSNES(
+    petsclib::LibPETSc.PetscLibType,
+    ts::LibPETSc.TS,
+) end
+
+LibPETSc.@for_petsc function LibPETSc.TSGetSNES(
+    petsclib::$UnionPetscLib,
+    ts::LibPETSc.TS,
+)
+    snes_ = Ref{LibPETSc.CSNES}(C_NULL)
+    LibPETSc.@chk ccall(
+        (:TSGetSNES, $petsc_library),
+        LibPETSc.PetscErrorCode,
+        (LibPETSc.CTS, Ptr{LibPETSc.CSNES}),
+        ts,
+        snes_,
+    )
+    return LibPETSc.PetscSNES(snes_[], petsclib)
+end
+
+"""
+    TSGetKSP(petsclib, ts)
+
+Return the linear solver held by `ts`.
+
+The generated three-argument form takes the solver as an input and nulls the
+caller's handle, so it cannot be used to read the solver back. 
+The `KSP` is owned by `ts` and must not be destroyed.
+
+# External Links
+$(_doc_external("TS/TSGetKSP"))
+"""
+function LibPETSc.TSGetKSP(petsclib::LibPETSc.PetscLibType, ts::LibPETSc.TS) end
+
+LibPETSc.@for_petsc function LibPETSc.TSGetKSP(
+    petsclib::$UnionPetscLib,
+    ts::LibPETSc.TS,
+)
+    ksp_ = Ref{LibPETSc.CKSP}(C_NULL)
+    LibPETSc.@chk ccall(
+        (:TSGetKSP, $petsc_library),
+        LibPETSc.PetscErrorCode,
+        (LibPETSc.CTS, Ptr{LibPETSc.CKSP}),
+        ts,
+        ksp_,
+    )
+    return LibPETSc.PetscKSP(ksp_[], petsclib)
+end
+
+"""
+    snes(ts::AbstractTS)
+
+The nonlinear solver `ts` steps with. It is owned by `ts`, so do not destroy it.
+
+Only the implicit methods build one. Asking an explicit method for its `SNES`
+creates an unused solver rather than reporting an error.
+
+# External Links
+$(_doc_external("TS/TSGetSNES"))
+"""
+snes(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetSNES(getlib(PetscLib), ts)
+
+"""
+    ksp(ts::AbstractTS)
+
+The linear solver `ts` steps with. It is owned by `ts`, so do not destroy it.
+
+PETSc only offers this for a problem declared `TS_LINEAR` with [`set_problem_type!`](@ref), 
+and raises `PETSC_ERR_ARG_WRONG` otherwise. The linear solver of a nonlinear problem 
+belongs to its `SNES`, so reach it through [`snes`](@ref).
+
+# External Links
+$(_doc_external("TS/TSGetKSP"))
+"""
+ksp(ts::AbstractTS{PetscLib}) where {PetscLib} =
+    LibPETSc.TSGetKSP(getlib(PetscLib), ts)
+
+"""
+    setup!(ts::AbstractTS)
+
+Complete the setup of `ts`. [`solve!`](@ref) calls this, so it is only needed
+when the setup must happen at a controlled point.
+
+# External Links
+$(_doc_external("TS/TSSetUp"))
+"""
+function setup!(ts::AbstractTS{PetscLib}) where {PetscLib}
+    LibPETSc.TSSetUp(getlib(PetscLib), ts)
+    return nothing
+end
+
+"""
+    set_from_options!(ts::AbstractTS)
+
+Apply the PETSc options database to `ts`.
+
+# External Links
+$(_doc_external("TS/TSSetFromOptions"))
+"""
+function set_from_options!(ts::AbstractTS{PetscLib}) where {PetscLib}
+    LibPETSc.TSSetFromOptions(getlib(PetscLib), ts)
+    return nothing
+end
+
+"""
+    TSSolve(petsclib, ts, ::Nothing)
+
+Integrate `ts` using the solution vector already set on it.
+
+The generated binding requires a vector. PETSc reads the solution set by
+`TSSetSolution` when it is handed `NULL` instead, which is what this overload passes.
+
+# External Links
+$(_doc_external("TS/TSSolve"))
+"""
+function LibPETSc.TSSolve(
+    petsclib::LibPETSc.PetscLibType,
+    ts::LibPETSc.TS,
+    ::Nothing,
+) end
+
+LibPETSc.@for_petsc function LibPETSc.TSSolve(
+    petsclib::$UnionPetscLib,
+    ts::LibPETSc.TS,
+    ::Nothing,
+)
+    LibPETSc.@chk ccall(
+        (:TSSolve, $petsc_library),
+        LibPETSc.PetscErrorCode,
+        (LibPETSc.CTS, LibPETSc.CVec),
+        ts,
+        C_NULL,
+    )
+    return nothing
+end
+
+# Options given to the constructor are applied here rather than there, so that
+# a DM and callbacks attached in between are visible to `TSSetFromOptions`.
+function _with_options(f, ts::AbstractTS{PetscLib}) where {PetscLib}
+    isnothing(ts.opts) && return f()
+    push!(ts.opts)
+    try
+        LibPETSc.TSSetFromOptions(PetscLib, ts)
+        return f()
+    finally
+        pop!(ts.opts)
+    end
+end
+
+"""
+    solve!(u::AbstractPetscVec, ts::AbstractTS)
+    solve!(ts::AbstractTS)
+
+Integrate `ts`, starting from `u` and returning it. 
+The second form uses the solution vector already set on `ts` and returns `ts`.
+
+`u` is registered with `TSSetSolution` before the solve. 
+Passing it to `TSSolve` alone leaves the stepper reading an uninitialized solution vector,
+which the implicit methods see as an initial condition of zero.
+
+Options passed to the [`TS`](@ref) constructor are applied here, 
+once the DM and the callbacks are attached.
+
+# External Links
+$(_doc_external("TS/TSSolve"))
+$(_doc_external("TS/TSSetSolution"))
+"""
+function solve!(
+    u::AbstractPetscVec{PetscLib},
+    ts::AbstractTS{PetscLib},
+) where {PetscLib}
+    LibPETSc.TSSetSolution(PetscLib, ts, u)
+    _with_options(ts) do
+        LibPETSc.TSSolve(PetscLib, ts, u)
+    end
+    return u
+end
+
+function solve!(ts::AbstractTS{PetscLib}) where {PetscLib}
+    _with_options(ts) do
+        LibPETSc.TSSolve(PetscLib, ts, nothing)
+    end
+    return ts
+end
+
+"""
+    step!(ts::AbstractTS)
+
+Take a single step. Unlike [`solve!`](@ref) this does not apply the options
+given to the constructor, and it ignores the time set by [`set_max_time!`](@ref).
+
+# External Links
+$(_doc_external("TS/TSStep"))
+"""
+function step!(ts::AbstractTS{PetscLib}) where {PetscLib}
+    LibPETSc.TSStep(getlib(PetscLib), ts)
+    return nothing
+end
+
+"""
+    reset!(ts::AbstractTS)
+
+Release the work vectors and matrices `ts` allocated, keeping the callbacks
+and the options.
+
+The clock is not part of that state: the time and the step count survive, so
+set them with [`set_time!`](@ref) and [`set_max_time!`](@ref) before integrating again.
+
+# External Links
+$(_doc_external("TS/TSReset"))
+"""
+function reset!(ts::AbstractTS{PetscLib}) where {PetscLib}
+    LibPETSc.TSReset(getlib(PetscLib), ts)
+    return nothing
+end
+
+"""
+    interpolate!(u::AbstractPetscVec, ts::AbstractTS, t)
+
+Fill `u` with the solution interpolated to time `t`, and return it.
+
+Only the methods that keep a dense output can do this, 
+and `t` must lie inside the step just taken.
+
+# External Links
+$(_doc_external("TS/TSInterpolate"))
+"""
+function interpolate!(
+    u::AbstractPetscVec{PetscLib},
+    ts::AbstractTS{PetscLib},
+    t,
+) where {PetscLib}
+    LibPETSc.TSInterpolate(getlib(PetscLib), ts, PetscLib.PetscReal(t), u)
+    return u
+end
+
+"""
+    user_ctx(ts::AbstractTS)
+
+Whatever was stored with [`set_user_ctx!`](@ref), or `nothing`.
+"""
+user_ctx(ts::AbstractTS) = ts.user_ctx
+
+"""
+    set_user_ctx!(ts::AbstractTS, ctx)
+
+Attach `ctx` to `ts`, to be handed back as the last argument of every callback
+that has a method accepting it.
+
+The object is held by `ts` on the Julia side, so it is kept alive and needs no pinning.
+"""
+function set_user_ctx!(ts::AbstractTS, ctx)
+    ts.user_ctx = ctx
+    return nothing
+end
+
+# Callbacks
+# ----------------------------------------------------------------------------
+#
+# Each setter stores the Julia function on the `ts` and hands PETSc a
+# `@cfunction` trampoline plus a pointer to the `ts` itself as the context, 
+# so the closure stays rooted for as long as the object lives. 
+
+# A callback may return an error code; anything else is treated as success.
+
+"""
+    TSSetRHSJacobian(petsclib, ts, A, P, fptr::Ptr{Cvoid}, ctx = C_NULL)
+
+Convenience overload for low-level TS RHS-Jacobian callbacks created with `@cfunction`.
+
+# External Links
+$(_doc_external("TS/TSSetRHSJacobian"))
+"""
+function LibPETSc.TSSetRHSJacobian(
+    petsclib::LibPETSc.PetscLibType,
+    ts::LibPETSc.TS,
+    A::AbstractPetscMat,
+    P::AbstractPetscMat,
+    fptr::Ptr{Cvoid},
+    ctx::Ptr{Cvoid} = C_NULL,
+) end
+
+LibPETSc.@for_petsc function LibPETSc.TSSetRHSJacobian(
+    petsclib::$UnionPetscLib,
+    ts::LibPETSc.TS,
+    A::AbstractPetscMat{$PetscLib},
+    P::AbstractPetscMat{$PetscLib},
+    fptr::Ptr{Cvoid},
+    ctx::Ptr{Cvoid} = C_NULL,
+)
+    typed_fptr = Base.unsafe_convert(Ptr{LibPETSc.TSRHSJacobianFn}, fptr)
+    LibPETSc.@chk ccall(
+        (:TSSetRHSJacobian, $petsc_library),
+        LibPETSc.PetscErrorCode,
+        (
+            LibPETSc.CTS,
+            LibPETSc.CMat,
+            LibPETSc.CMat,
+            Ptr{LibPETSc.TSRHSJacobianFn},
+            Ptr{Cvoid},
+        ),
+        ts,
+        A,
+        P,
+        typed_fptr,
+        ctx,
+    )
+    return nothing
+end
+
+# A callback may return a PETSc error code; anything else counts as success.
+_errorcode(r) =
+    r isa Integer ? LibPETSc.PetscErrorCode(r) : LibPETSc.PetscErrorCode(0)
+
+# "error in library called by PETSc", from `petscsystypes.h`.
+const _PETSC_ERR_LIB = LibPETSc.PetscErrorCode(76)
+
+# Call `f` and turn its result into a PETSc error code.
+#
+# A Julia exception must not cross the `@cfunction` boundary: PETSc is C and
+# cannot unwind a Julia frame, so an escaping error takes the process down. 
+# Log it here instead and report failure to PETSc, which unwinds its own stack 
+# and leaves `@chk` to raise a `PetscError` from the enclosing `solve!`.
+function _run_callback(f, name)
+    try
+        return _errorcode(f())
+    catch e
+        bt = catch_backtrace()
+        # Reporting is itself Julia code, and nothing here may throw either.
+        try
+            @error "PETSc.jl: the $name callback failed" exception = (e, bt)
+        catch
+            Core.println("PETSc.jl: the ", name, " callback failed")
+        end
+        return _PETSC_ERR_LIB
+    end
+end
+
+"""
+    set_rhs_function!(f!, ts::AbstractTS, r = nothing)
+    set_rhs_function!(ts::AbstractTS, f!, r = nothing)
+
+Set the right-hand side ``G`` of an explicit problem ``du/dt = G(t, u)``.
+
+`f!` is called as `f!(F, ts, t, u)`, filling the vector `F`. If `ts.user_ctx`
+is set, `f!(F, ts, t, u, user_ctx)` is used instead when that method exists.
+
+`r` is an optional template vector for the residual.
+
+# External Links
+$(_doc_external("TS/TSSetRHSFunction"))
+"""
+set_rhs_function!(ts::AbstractTS, f!, r = nothing) =
+    set_rhs_function!(f!, ts, r)
+
+mutable struct TSSetRHSFunctionFn{PetscLib, PetscReal} end
+function (::TSSetRHSFunctionFn{PetscLib, PetscReal})(
+    ts_ptr::CTS,
+    t::PetscReal,
+    u_ptr::CVec,
+    F_ptr::CVec,
+    ctx::Ptr{Cvoid},
+) where {PetscLib, PetscReal}
+    ts = unsafe_pointer_to_objref(ctx)
+    actual_ts = TS{PetscLib}(ts_ptr, getlib(PetscLib).age)
+    u = PetscVec{PetscLib}(u_ptr)
+    F = PetscVec{PetscLib}(F_ptr)
+
+    _run_callback("rhs_function!") do
+        if Base.applicable(ts.rhs_function!, F, actual_ts, t, u, ts.user_ctx)
+            ts.rhs_function!(F, actual_ts, t, u, ts.user_ctx)
+        else
+            ts.rhs_function!(F, actual_ts, t, u)
+        end
+    end
+end
+
+LibPETSc.@for_petsc function set_rhs_function!(
+    f!,
+    ts::AbstractTS{$PetscLib},
+    r::Union{Nothing, AbstractPetscVec{$PetscLib}} = nothing,
+)
+    fptr = @cfunction(
+        TSSetRHSFunctionFn{$PetscLib, $PetscReal}(),
+        LibPETSc.PetscErrorCode,
+        (CTS, $PetscReal, CVec, CVec, Ptr{Cvoid})
+    )
+    ts.rhs_function! = f!
+    LibPETSc.TSSetRHSFunction($PetscLib, ts, r, fptr, pointer_from_objref(ts))
+    return nothing
+end
+
+"""
+    set_rhs_jacobian!(updateJ!, ts::AbstractTS, A, P = A)
+    set_rhs_jacobian!(ts::AbstractTS, updateJ!, A, P = A)
+
+Set the Jacobian of the right-hand side ``G``.
+
+`updateJ!` is called as `updateJ!(A, P, ts, t, u)`, filling the Jacobian `A`
+and the preconditioning matrix `P`. If `ts.user_ctx` is set,
+`updateJ!(A, P, ts, t, u, user_ctx)` is used instead when that method exists.
+
+# External Links
+$(_doc_external("TS/TSSetRHSJacobian"))
+"""
+set_rhs_jacobian!(ts::AbstractTS, updateJ!, A, P = A) =
+    set_rhs_jacobian!(updateJ!, ts, A, P)
+
+mutable struct TSSetRHSJacobianFn{PetscLib, PetscReal} end
+function (::TSSetRHSJacobianFn{PetscLib, PetscReal})(
+    ts_ptr::CTS,
+    t::PetscReal,
+    u_ptr::CVec,
+    A_ptr::CMat,
+    P_ptr::CMat,
+    ctx::Ptr{Cvoid},
+) where {PetscLib, PetscReal}
+    ts = unsafe_pointer_to_objref(ctx)
+    actual_ts = TS{PetscLib}(ts_ptr, getlib(PetscLib).age)
+    u = PetscVec{PetscLib}(u_ptr)
+    A = PetscMat{PetscLib}(A_ptr)
+    P = PetscMat{PetscLib}(P_ptr)
+
+    _run_callback("rhs_jacobian!") do
+        if Base.applicable(ts.rhs_jacobian!, A, P, actual_ts, t, u, ts.user_ctx)
+            ts.rhs_jacobian!(A, P, actual_ts, t, u, ts.user_ctx)
+        else
+            ts.rhs_jacobian!(A, P, actual_ts, t, u)
+        end
+    end
+end
+
+LibPETSc.@for_petsc function set_rhs_jacobian!(
+    updateJ!,
+    ts::AbstractTS{$PetscLib},
+    A::AbstractPetscMat{$PetscLib},
+    P::AbstractPetscMat{$PetscLib} = A,
+)
+    fptr = @cfunction(
+        TSSetRHSJacobianFn{$PetscLib, $PetscReal}(),
+        LibPETSc.PetscErrorCode,
+        (CTS, $PetscReal, CVec, CMat, CMat, Ptr{Cvoid})
+    )
+    ts.rhs_jacobian! = updateJ!
+    LibPETSc.TSSetRHSJacobian(
+        $PetscLib,
+        ts,
+        A,
+        P,
+        fptr,
+        pointer_from_objref(ts),
+    )
+    return nothing
+end
+
+"""
+    set_ifunction!(f!, ts::AbstractTS, r = nothing)
+    set_ifunction!(ts::AbstractTS, f!, r = nothing)
+
+Set the residual ``F`` of an implicit problem ``F(t, u, du/dt) = 0``.
+
+`f!` is called as `f!(F, ts, t, u, u_t)`, filling the vector `F`. 
+If `ts.user_ctx` is set, `f!(F, ts, t, u, u_t, user_ctx)` is used instead 
+when that method exists.
+
+# External Links
+$(_doc_external("TS/TSSetIFunction"))
+"""
+set_ifunction!(ts::AbstractTS, f!, r = nothing) = set_ifunction!(f!, ts, r)
+
+mutable struct TSSetIFunctionFn{PetscLib, PetscReal} end
+function (::TSSetIFunctionFn{PetscLib, PetscReal})(
+    ts_ptr::CTS,
+    t::PetscReal,
+    u_ptr::CVec,
+    udot_ptr::CVec,
+    F_ptr::CVec,
+    ctx::Ptr{Cvoid},
+) where {PetscLib, PetscReal}
+    ts = unsafe_pointer_to_objref(ctx)
+    actual_ts = TS{PetscLib}(ts_ptr, getlib(PetscLib).age)
+    u = PetscVec{PetscLib}(u_ptr)
+    u_t = PetscVec{PetscLib}(udot_ptr)
+    F = PetscVec{PetscLib}(F_ptr)
+
+    _run_callback("ifunction!") do
+        if Base.applicable(ts.ifunction!, F, actual_ts, t, u, u_t, ts.user_ctx)
+            ts.ifunction!(F, actual_ts, t, u, u_t, ts.user_ctx)
+        else
+            ts.ifunction!(F, actual_ts, t, u, u_t)
+        end
+    end
+end
+
+LibPETSc.@for_petsc function set_ifunction!(
+    f!,
+    ts::AbstractTS{$PetscLib},
+    r::Union{Nothing, AbstractPetscVec{$PetscLib}} = nothing,
+)
+    fptr = @cfunction(
+        TSSetIFunctionFn{$PetscLib, $PetscReal}(),
+        LibPETSc.PetscErrorCode,
+        (CTS, $PetscReal, CVec, CVec, CVec, Ptr{Cvoid})
+    )
+    ts.ifunction! = f!
+    LibPETSc.TSSetIFunction($PetscLib, ts, r, fptr, pointer_from_objref(ts))
+    return nothing
+end
+
+"""
+    set_ijacobian!(updateJ!, ts::AbstractTS, A, P = A)
+    set_ijacobian!(ts::AbstractTS, updateJ!, A, P = A)
+
+Set the Jacobian of the implicit residual ``F``.
+
+`updateJ!` is called as `updateJ!(A, P, ts, t, u, u_t, shift)` and should fill
+`A` with ``dF/du + shift * dF/du_t``. If `ts.user_ctx` is set, the method
+taking a trailing `user_ctx` is used instead when it exists.
+
+# External Links
+$(_doc_external("TS/TSSetIJacobian"))
+"""
+set_ijacobian!(ts::AbstractTS, updateJ!, A, P = A) =
+    set_ijacobian!(updateJ!, ts, A, P)
+
+mutable struct TSSetIJacobianFn{PetscLib, PetscReal} end
+function (::TSSetIJacobianFn{PetscLib, PetscReal})(
+    ts_ptr::CTS,
+    t::PetscReal,
+    u_ptr::CVec,
+    udot_ptr::CVec,
+    shift::PetscReal,
+    A_ptr::CMat,
+    P_ptr::CMat,
+    ctx::Ptr{Cvoid},
+) where {PetscLib, PetscReal}
+    ts = unsafe_pointer_to_objref(ctx)
+    actual_ts = TS{PetscLib}(ts_ptr, getlib(PetscLib).age)
+    u = PetscVec{PetscLib}(u_ptr)
+    u_t = PetscVec{PetscLib}(udot_ptr)
+    A = PetscMat{PetscLib}(A_ptr)
+    P = PetscMat{PetscLib}(P_ptr)
+
+    _run_callback("ijacobian!") do
+        if Base.applicable(
+            ts.ijacobian!,
+            A,
+            P,
+            actual_ts,
+            t,
+            u,
+            u_t,
+            shift,
+            ts.user_ctx,
+        )
+            ts.ijacobian!(A, P, actual_ts, t, u, u_t, shift, ts.user_ctx)
+        else
+            ts.ijacobian!(A, P, actual_ts, t, u, u_t, shift)
+        end
+    end
+end
+
+LibPETSc.@for_petsc function set_ijacobian!(
+    updateJ!,
+    ts::AbstractTS{$PetscLib},
+    A::AbstractPetscMat{$PetscLib},
+    P::AbstractPetscMat{$PetscLib} = A,
+)
+    fptr = @cfunction(
+        TSSetIJacobianFn{$PetscLib, $PetscReal}(),
+        LibPETSc.PetscErrorCode,
+        (CTS, $PetscReal, CVec, CVec, $PetscReal, CMat, CMat, Ptr{Cvoid})
+    )
+    ts.ijacobian! = updateJ!
+    LibPETSc.TSSetIJacobian(
+        $PetscLib,
+        ts,
+        A,
+        P,
+        fptr,
+        pointer_from_objref(ts),
+    )
+    return nothing
+end
+
+"""
+    set_monitor!(f, ts::AbstractTS)
+    set_monitor!(ts::AbstractTS, f)
+
+Call `f` once after every accepted step.
+
+`f` is called as `f(ts, step, t, u)`, where `step` counts the steps taken, `t`
+is the time reached and `u` holds the solution there. If `ts.user_ctx` is set,
+`f(ts, step, t, u, user_ctx)` is used instead when that method exists. 
+`u` is owned by `ts` and must not be destroyed.
+
+Only one monitor can be set this way; a second call replaces the first. 
+The monitors PETSc installs from the options database, such as `-ts_monitor`, 
+are unaffected.
+
+# External Links
+$(_doc_external("TS/TSMonitorSet"))
+"""
+set_monitor!(ts::AbstractTS, f) = set_monitor!(f, ts)
+
+mutable struct TSMonitorSetFn{PetscLib, PetscInt, PetscReal} end
+function (::TSMonitorSetFn{PetscLib, PetscInt, PetscReal})(
+    ts_ptr::CTS,
+    step::PetscInt,
+    t::PetscReal,
+    u_ptr::CVec,
+    ctx::Ptr{Cvoid},
+) where {PetscLib, PetscInt, PetscReal}
+    ts = unsafe_pointer_to_objref(ctx)
+    actual_ts = TS{PetscLib}(ts_ptr, getlib(PetscLib).age)
+    u = PetscVec{PetscLib}(u_ptr)
+
+    _run_callback("monitor") do
+        if Base.applicable(ts.monitor, actual_ts, step, t, u, ts.user_ctx)
+            ts.monitor(actual_ts, step, t, u, ts.user_ctx)
+        else
+            ts.monitor(actual_ts, step, t, u)
+        end
+    end
+end
+
+LibPETSc.@for_petsc function set_monitor!(f, ts::AbstractTS{$PetscLib})
+    fptr = @cfunction(
+        TSMonitorSetFn{$PetscLib, $PetscInt, $PetscReal}(),
+        LibPETSc.PetscErrorCode,
+        (CTS, $PetscInt, $PetscReal, CVec, Ptr{Cvoid})
+    )
+    ts.monitor = f
+    LibPETSc.TSMonitorSet($PetscLib, ts, fptr, pointer_from_objref(ts))
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ include("low_level_ts.jl")      # Low-level TS functions
 include("ts_ex51.jl")           # Regression test for repeated ex51 solves
 include("ts_ex51_implicit.jl")  # Regression test for repeated implicit Gauss solves
 include("ts_ex16.jl")           # Regression test for the van der Pol IMEX example
+include("ts_scenarios.jl")      # High-level TS: ex16 equivalence + a damping sweep
 include("low_level_is.jl")      # Low-level IS functions
 include("low_level_petscsection.jl")  # Low-level PetscSection functions
 include("low_level_tao.jl")     # Low-level Tao functions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ include("options.jl")       # autowrapped
 include("ksp.jl")           # autowrapped
 include("snes.jl")          # autowrapped
 include("snes_helpers.jl")  # small helper tests for SNES return-style wrappers
+include("ts.jl")            # high-level TS interface
 include("dmda.jl")          # autowrapped
 include("dmstag.jl")        # autowrapped
 include("dmplex.jl")        # DMPlex tests

--- a/test/ts.jl
+++ b/test/ts.jl
@@ -1,0 +1,516 @@
+using Test
+using PETSc
+using MPI
+using LinearAlgebra: I, inv
+using Logging: Logging, NullLogger, with_logger
+
+if !Sys.iswindows()
+    MPI.Initialized() || MPI.Init()
+end
+
+# High-level TS interface.
+#
+# The reference values are the exact solutions of the *discrete* scheme, not of
+# the ODE, so the tolerances only have to cover round-off and a broken callback
+# still shows up immediately.
+
+@testset "TS" begin
+    comm = Sys.iswindows() ? LibPETSc.PETSC_COMM_SELF : MPI.COMM_SELF
+
+    for petsclib in PETSc.petsclibs
+        PETSc.initialize(petsclib)
+        PetscScalar = petsclib.PetscScalar
+        PetscReal = petsclib.PetscReal
+        PetscInt = petsclib.PetscInt
+        rtol = PetscReal == Float32 ? 1e-4 : 1e-9
+
+        # du/dt = -u, u(0) = 1. Backward Euler with a fixed step gives
+        # u_n = (1 + dt)^-n exactly, which is what the implicit paths below are
+        # measured against.
+        decay(dt, n) = PetscReal(1 / (1 + dt)^n)
+
+        @testset "construction and introspection" begin
+            ts = PETSc.TS(petsclib, comm)
+            @test ts isa PETSc.LibPETSc.TS
+            @test ts.ptr != C_NULL
+            @test occursin("TS", sprint(show, ts))
+            # No method has been chosen yet.
+            @test PETSc.type(ts) === nothing
+
+            PETSc.set_type!(ts, :beuler)
+            @test PETSc.type(ts) === :beuler
+            PETSc.set_type!(ts, :bdf)
+            @test PETSc.type(ts) === :bdf
+
+            @test PETSc.comm(ts) isa MPI.Comm
+            @test PETSc.dm(ts).ptr != C_NULL
+
+            # Nothing is read from the options database until `solve!`.
+            ts_opt = PETSc.TS(petsclib, comm; ts_type = "rk")
+            @test PETSc.type(ts_opt) === nothing
+            PETSc.destroy!(ts_opt)
+
+            PETSc.destroy!(ts)
+            @test ts.ptr == C_NULL
+        end
+
+        @testset "time and step controls" begin
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :beuler)
+
+            PETSc.set_time!(ts, 0.25)
+            @test PETSc.current_time(ts) ≈ 0.25
+            PETSc.set_timestep!(ts, 0.01)
+            @test PETSc.timestep(ts) ≈ 0.01
+            PETSc.set_max_time!(ts, 2.0)
+            @test PETSc.max_time(ts) ≈ 2.0
+            PETSc.set_max_steps!(ts, 17)
+            @test PETSc.max_steps(ts) == 17
+            @test PETSc.step_number(ts) == 0
+
+            @test PETSc.converged_reason(ts) ==
+                  PETSc.LibPETSc.TS_CONVERGED_ITERATING
+
+            PETSc.destroy!(ts)
+        end
+
+        @testset "tolerances" begin
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :bdf)
+
+            PETSc.set_tolerances!(ts; atol = 1e-9, rtol = 1e-7)
+            tol = PETSc.tolerances(ts)
+            @test tol.atol ≈ 1e-9
+            @test tol.rtol ≈ 1e-7
+            # Only the scalar tolerances were set, so the vector ones are null.
+            @test tol.vatol.ptr == C_NULL
+            @test tol.vrtol.ptr == C_NULL
+
+            vatol = PETSc.VecSeq(petsclib, 2)
+            PETSc.set_tolerances!(ts; vatol = vatol)
+            @test PETSc.tolerances(ts).vatol.ptr != C_NULL
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(vatol)
+        end
+
+        @testset "explicit right-hand side" begin
+            dt, n = 0.01, 100
+
+            # `do` block form: the callback comes first, so this works.
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :rk)
+            PETSc.set_adapt_type!(ts, :none)
+            u = PETSc.VecSeq(petsclib, 1)
+            u[1] = PetscScalar(1)
+            PETSc.assemble!(u)
+
+            calls = Ref(0)
+            PETSc.set_rhs_function!(ts) do F, _ts, _t, x
+                calls[] += 1
+                PETSc.withlocalarray!(
+                    (x, F);
+                    read = (true, false),
+                    write = (false, true),
+                ) do xa, Fa
+                    Fa[1] = -xa[1]
+                end
+                return 0
+            end
+
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, dt)
+            PETSc.set_max_time!(ts, 1.0)
+            PETSc.solve!(u, ts)
+
+            @test calls[] > 0
+            @test PETSc.converged_reason(ts) ==
+                  PETSc.LibPETSc.TS_CONVERGED_TIME
+            @test PETSc.step_number(ts) == n
+            @test PETSc.solve_time(ts) ≈ 1.0
+            # A Runge-Kutta method at this step size is well inside 1e-3 of the
+            # true solution; a callback that never ran would not be.
+            @test u[1] ≈ exp(-one(PetscReal)) rtol = 1e-3
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+
+            # Reversed argument order, for a callback that is already a value.
+            ts2 = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts2, :rk)
+            PETSc.set_adapt_type!(ts2, :none)
+            u2 = PETSc.VecSeq(petsclib, 1)
+            u2[1] = PetscScalar(1)
+            PETSc.assemble!(u2)
+            PETSc.set_rhs_function!(ts2, (F, _ts, _t, x) -> (F[1] = -x[1]; 0))
+            PETSc.set_time!(ts2, 0.0)
+            PETSc.set_timestep!(ts2, dt)
+            PETSc.set_max_time!(ts2, 1.0)
+            PETSc.solve!(u2, ts2)
+            @test u2[1] ≈ exp(-one(PetscReal)) rtol = 1e-3
+
+            PETSc.destroy!(ts2)
+            PETSc.destroy(u2)
+        end
+
+        @testset "implicit residual and Jacobian" begin
+            dt, n = 0.1, 10
+
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :beuler)
+            PETSc.set_adapt_type!(ts, :none)
+
+            u = PETSc.VecSeq(petsclib, 1)
+            u[1] = PetscScalar(1)
+            PETSc.assemble!(u)
+
+            J = PETSc.MatSeqAIJ(petsclib, 1, 1, PetscInt(1))
+            J[1, 1] = PetscScalar(1)
+            PETSc.assemble!(J)
+
+            PETSc.set_ifunction!(ts) do F, _ts, _t, x, xdot
+                PETSc.withlocalarray!(
+                    (x, xdot, F);
+                    read = (true, true, false),
+                    write = (false, false, true),
+                ) do xa, xda, Fa
+                    Fa[1] = xda[1] + xa[1]
+                end
+                return 0
+            end
+
+            # F = u_t + u, so dF/du + shift dF/du_t = 1 + shift.
+            PETSc.set_ijacobian!(ts, J) do A, _P, _ts, _t, _x, _xdot, shift
+                A[1, 1] = PetscScalar(shift + 1)
+                PETSc.assemble!(A)
+                return 0
+            end
+
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, dt)
+            PETSc.set_max_time!(ts, 1.0)
+            PETSc.solve!(u, ts)
+
+            @test PETSc.step_number(ts) == n
+            @test u[1] ≈ decay(dt, n) rtol = rtol
+            @test PETSc.snes_iterations(ts) >= n
+            @test PETSc.step_rejections(ts) == 0
+            @test PETSc.snes_failures(ts) == 0
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+            PETSc.destroy(J)
+        end
+
+        @testset "right-hand side Jacobian" begin
+            dt, n = 0.1, 10
+
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :beuler)
+            PETSc.set_adapt_type!(ts, :none)
+
+            u = PETSc.VecSeq(petsclib, 1)
+            u[1] = PetscScalar(1)
+            PETSc.assemble!(u)
+
+            J = PETSc.MatSeqAIJ(petsclib, 1, 1, PetscInt(1))
+            J[1, 1] = PetscScalar(1)
+            PETSc.assemble!(J)
+
+            PETSc.set_rhs_function!(ts, (F, _ts, _t, x) -> (F[1] = -x[1]; 0))
+            jac_calls = Ref(0)
+            PETSc.set_rhs_jacobian!(ts, J) do A, _P, _ts, _t, _x
+                jac_calls[] += 1
+                A[1, 1] = PetscScalar(-1)
+                PETSc.assemble!(A)
+                return 0
+            end
+
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, dt)
+            PETSc.set_max_time!(ts, 1.0)
+            PETSc.solve!(u, ts)
+
+            @test jac_calls[] > 0
+            @test u[1] ≈ decay(dt, n) rtol = rtol
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+            PETSc.destroy(J)
+        end
+
+        @testset "coupled system exercises the shift" begin
+            # du/dt = A u with A = [0 1; -1 0], so the Jacobian has off-diagonal
+            # entries and a wrong shift convention cannot pass unnoticed.
+            dt, n = 0.05, 20
+            A = [0.0 1.0; -1.0 0.0]
+            step = inv(I - dt * A)
+            expected = (step^n) * [1.0, 0.0]
+
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :beuler)
+            PETSc.set_adapt_type!(ts, :none)
+
+            u = PETSc.VecSeq(petsclib, 2)
+            u[1] = PetscScalar(1)
+            u[2] = PetscScalar(0)
+            PETSc.assemble!(u)
+
+            J = PETSc.MatSeqAIJ(petsclib, 2, 2, PetscInt(2))
+            for i in 1:2, j in 1:2
+                J[i, j] = PetscScalar(0)
+            end
+            PETSc.assemble!(J)
+
+            PETSc.set_ifunction!(ts) do F, _ts, _t, x, xdot
+                PETSc.withlocalarray!(
+                    (x, xdot, F);
+                    read = (true, true, false),
+                    write = (false, false, true),
+                ) do xa, xda, Fa
+                    Fa[1] = xda[1] - xa[2]
+                    Fa[2] = xda[2] + xa[1]
+                end
+                return 0
+            end
+
+            PETSc.set_ijacobian!(ts, J) do M, _P, _ts, _t, _x, _xdot, shift
+                M[1, 1] = PetscScalar(shift)
+                M[1, 2] = PetscScalar(-1)
+                M[2, 1] = PetscScalar(1)
+                M[2, 2] = PetscScalar(shift)
+                PETSc.assemble!(M)
+                return 0
+            end
+
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, dt)
+            PETSc.set_max_time!(ts, n * dt)
+            PETSc.solve!(u, ts)
+
+            @test u[1] ≈ expected[1] rtol = rtol
+            @test u[2] ≈ expected[2] rtol = rtol
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+            PETSc.destroy(J)
+        end
+
+        @testset "user context" begin
+            dt, n = 0.1, 10
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :beuler)
+            PETSc.set_adapt_type!(ts, :none)
+
+            @test PETSc.user_ctx(ts) === nothing
+            PETSc.set_user_ctx!(ts, (rate = PetscReal(2),))
+            @test PETSc.user_ctx(ts).rate == 2
+
+            u = PETSc.VecSeq(petsclib, 1)
+            u[1] = PetscScalar(1)
+            PETSc.assemble!(u)
+
+            seen = Ref(false)
+            # The method taking a trailing context is the one that must be
+            # picked, since `user_ctx` is set.
+            PETSc.set_rhs_function!(ts) do F, _ts, _t, x, ctx
+                seen[] = true
+                F[1] = -ctx.rate * x[1]
+                return 0
+            end
+
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, dt)
+            PETSc.set_max_time!(ts, 1.0)
+            PETSc.solve!(u, ts)
+
+            @test seen[]
+            @test u[1] ≈ PetscReal(1 / (1 + 2dt)^n) rtol = rtol
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+        end
+
+        @testset "monitor" begin
+            dt, n = 0.1, 10
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :beuler)
+            PETSc.set_adapt_type!(ts, :none)
+
+            u = PETSc.VecSeq(petsclib, 1)
+            u[1] = PetscScalar(1)
+            PETSc.assemble!(u)
+            PETSc.set_rhs_function!(ts, (F, _ts, _t, x) -> (F[1] = -x[1]; 0))
+
+            steps = Int[]
+            times = Float64[]
+            PETSc.set_monitor!(ts) do _ts, step, t, x
+                push!(steps, Int(step))
+                push!(times, Float64(t))
+                return 0
+            end
+
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, dt)
+            PETSc.set_max_time!(ts, 1.0)
+            PETSc.solve!(u, ts)
+
+            # Once before the first step and once after each one.
+            @test steps == collect(0:n)
+            @test times[1] ≈ 0.0
+            @test times[end] ≈ 1.0
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+        end
+
+        @testset "solve! without a vector" begin
+            dt, n = 0.1, 10
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :beuler)
+            PETSc.set_adapt_type!(ts, :none)
+
+            u = PETSc.VecSeq(petsclib, 1)
+            u[1] = PetscScalar(1)
+            PETSc.assemble!(u)
+            PETSc.set_solution!(ts, u)
+            @test PETSc.solution(ts).ptr == u.ptr
+
+            PETSc.set_rhs_function!(ts, (F, _ts, _t, x) -> (F[1] = -x[1]; 0))
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, dt)
+            PETSc.set_max_time!(ts, 1.0)
+
+            @test PETSc.solve!(ts) === ts
+            @test u[1] ≈ decay(dt, n) rtol = rtol
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+        end
+
+        @testset "options are applied at solve time" begin
+            dt, n = 0.1, 10
+            # `ts_type` only takes effect in `solve!`, after the callbacks are
+            # attached.
+            ts = PETSc.TS(
+                petsclib,
+                comm;
+                ts_type = "beuler",
+                ts_adapt_type = "none",
+            )
+            u = PETSc.VecSeq(petsclib, 1)
+            u[1] = PetscScalar(1)
+            PETSc.assemble!(u)
+            PETSc.set_rhs_function!(ts, (F, _ts, _t, x) -> (F[1] = -x[1]; 0))
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, dt)
+            PETSc.set_max_time!(ts, 1.0)
+            PETSc.solve!(u, ts)
+
+            @test PETSc.type(ts) === :beuler
+            @test u[1] ≈ decay(dt, n) rtol = rtol
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+        end
+
+        @testset "stepping by hand" begin
+            dt = 0.1
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :beuler)
+            PETSc.set_adapt_type!(ts, :none)
+
+            u = PETSc.VecSeq(petsclib, 1)
+            u[1] = PetscScalar(1)
+            PETSc.assemble!(u)
+            PETSc.set_solution!(ts, u)
+            PETSc.set_rhs_function!(ts, (F, _ts, _t, x) -> (F[1] = -x[1]; 0))
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, dt)
+            PETSc.set_max_time!(ts, 1.0)
+
+            PETSc.setup!(ts)
+            PETSc.step!(ts)
+            @test PETSc.step_number(ts) == 1
+            @test PETSc.current_time(ts) ≈ dt
+            @test u[1] ≈ decay(dt, 1) rtol = rtol
+
+            w = PETSc.VecSeq(petsclib, 1)
+            PETSc.interpolate!(w, ts, dt / 2)
+            @test w.ptr != C_NULL
+            @test isfinite(abs(w[1]))
+
+            PETSc.reset!(ts)
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+            PETSc.destroy(w)
+        end
+
+        @testset "sub-solvers" begin
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :beuler)
+
+            s = PETSc.snes(ts)
+            @test s isa PETSc.LibPETSc.PetscSNES
+            @test s.ptr != C_NULL
+            # The handle we are given must survive being asked for twice; the
+            # generated three-argument form nulls it instead.
+            @test PETSc.snes(ts).ptr == s.ptr
+
+            # A KSP is only offered for a problem declared linear.
+            PETSc.set_problem_type!(ts, PETSc.LibPETSc.TS_LINEAR)
+            k = PETSc.ksp(ts)
+            @test k isa PETSc.LibPETSc.PetscKSP
+            @test k.ptr != C_NULL
+
+            PETSc.destroy!(ts)
+        end
+
+        @testset "destruction" begin
+            ts = PETSc.TS(petsclib, comm; ts_type = "beuler")
+            @test !isnothing(ts.opts)
+            PETSc.destroy!(ts)
+            @test ts.ptr == C_NULL
+            @test isnothing(ts.opts)
+            # Destroying twice is a no-op, not an error.
+            PETSc.destroy!(ts)
+            @test ts.ptr == C_NULL
+
+            # `destroy` keeps working for code written against the rest of the
+            # package.
+            ts2 = PETSc.TS(petsclib, comm)
+            PETSc.destroy(ts2)
+            @test ts2.ptr == C_NULL
+        end
+
+        @testset "a callback that throws is reported, not fatal" begin
+            ts = PETSc.TS(petsclib, comm)
+            PETSc.set_type!(ts, :rk)
+            PETSc.set_adapt_type!(ts, :none)
+            u = PETSc.VecSeq(petsclib, 1)
+            u[1] = PetscScalar(1)
+            PETSc.assemble!(u)
+            PETSc.set_rhs_function!(ts) do _F, _ts, _t, _x
+                error("deliberate failure from a user callback")
+            end
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, 0.1)
+            PETSc.set_max_time!(ts, 1.0)
+
+            # The trampoline logs the Julia error and reports failure to PETSc,
+            # which unwinds and leaves `@chk` to raise. Both it and PETSc's own
+            # traceback are silenced here to keep the test output readable.
+            @test_throws PETSc.LibPETSc.PetscError with_logger(NullLogger()) do
+                redirect_stderr(devnull) do
+                    PETSc.solve!(u, ts)
+                end
+            end
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+        end
+
+        PETSc.finalize(petsclib)
+    end
+end

--- a/test/ts_scenarios.jl
+++ b/test/ts_scenarios.jl
@@ -1,0 +1,235 @@
+using Test
+using PETSc
+using MPI
+
+# Two scenarios for the high-level TS interface.
+#
+# The first solves a problem the package already solves through the low-level
+# bindings, and checks the two agree to the last digit. The second is shaped
+# the way the low-level layer makes awkward.
+#
+# `examples/ex16.jl` is loaded into its own module because `test/ts_ex16.jl`
+# also includes it, and its `@cfunction` pointers are `const`: a second
+# include into the same namespace would be a redefinition error, and the order
+# the two test files run in should not matter.
+module Ex16Reference
+include(joinpath(dirname(dirname(@__FILE__)), "examples", "ex16.jl"))
+end
+
+@testset "High-level TS scenarios" begin
+    petsclib = PETSc.getlib(PetscScalar = Float64)
+    PETSc.initialize(petsclib)
+    PetscScalar = petsclib.PetscScalar
+    PetscInt = petsclib.PetscInt
+    comm = Sys.iswindows() ? LibPETSc.PETSC_COMM_SELF : MPI.COMM_SELF
+
+    @testset "van der Pol: same answer as the low-level ex16" begin
+        # `examples/ex16.jl` is PETSc's TS tutorial ex16 written against the
+        # low-level bindings: four `@cfunction` blocks, a mutable context
+        # struct, `pointer_from_objref`, and a `GC.@preserve` region wrapped
+        # around every registration. 
+        # Here we is the same problem, the same method and the same step size 
+        # through the high-level interface, and the assertion is that the two agree exactly.
+        mu = 1000.0
+        imex = true
+        final_time = 0.5
+        dt = 0.01
+
+        ts = PETSc.TS(
+            petsclib,
+            comm;
+            exact_final_time = PETSc.LibPETSc.TS_EXACTFINALTIME_STEPOVER,
+        )
+        PETSc.set_type!(ts, :beuler)
+        PETSc.set_problem_type!(ts, PETSc.LibPETSc.TS_NONLINEAR)
+        PETSc.set_user_ctx!(ts, (; mu, imex))
+
+        u = PETSc.VecSeq(petsclib, 2)
+        PETSc.withlocalarray!(u; read = false, write = true) do ua
+            ua[1] = 2.0
+            ua[2] = -2.0 / 3.0 + 10.0 / (81.0 * mu) - 292.0 / (2187.0 * mu * mu)
+        end
+        PETSc.set_solution!(ts, u)
+
+        jac = PETSc.MatSeqAIJ(petsclib, 2, 2, PetscInt(2))
+        jac[1, [1, 2]] = PetscScalar.([1.0, 1.0])
+        jac[2, [1, 2]] = PetscScalar.([1.0, 1.0])
+        PETSc.assemble!(jac)
+        PETSc.LibPETSc.MatZeroEntries(petsclib, jac)
+
+        # G(u, t), the explicit half of the IMEX split.
+        PETSc.set_rhs_function!(ts) do F, _ts, _t, x, ctx
+            PETSc.withlocalarray!(
+                (x, F);
+                read = (true, false),
+                write = (false, true),
+            ) do xa, Fa
+                Fa[1] = ctx.imex ? xa[2] : 0.0
+                Fa[2] = 0.0
+            end
+            return 0
+        end
+
+        # F(u_t, u, t), the implicit half.
+        PETSc.set_ifunction!(ts) do F, _ts, _t, x, xdot, ctx
+            PETSc.withlocalarray!(
+                (x, xdot, F);
+                read = (true, true, false),
+                write = (false, false, true),
+            ) do xa, xda, Fa
+                Fa[1] = xda[1] + (ctx.imex ? 0.0 : xa[2])
+                Fa[2] =
+                    xda[2] -
+                    ctx.mu *
+                    ((1.0 - xa[1] * xa[1]) * xa[2] - xa[1])
+            end
+            return 0
+        end
+
+        PETSc.set_ijacobian!(ts, jac) do A, _P, _ts, _t, x, _xdot, shift, ctx
+            x1, x2 = PETSc.withlocalarray!(x; read = true, write = false) do xa
+                (xa[1], xa[2])
+            end
+            A[1, 1] = PetscScalar(shift)
+            A[1, 2] = PetscScalar(ctx.imex ? 0.0 : 1.0)
+            A[2, 1] = PetscScalar(ctx.mu * (2.0 * x1 * x2 + 1.0))
+            A[2, 2] = PetscScalar(shift - ctx.mu * (1.0 - x1 * x1))
+            PETSc.assemble!(A)
+            return 0
+        end
+
+        PETSc.set_timestep!(ts, dt)
+        PETSc.set_max_time!(ts, final_time)
+
+        PETSc.solve!(u, ts)
+
+        solution = copy(u[:])
+        steps = PETSc.step_number(ts)
+        solve_time = PETSc.solve_time(ts)
+
+        reference = Ex16Reference.solve_ex16(;
+            petsclib,
+            mu,
+            imex,
+            final_time,
+            dt,
+            options = String[],
+            verbose = false,
+        )
+
+        # Same arithmetic in the same order, so this is exact, not merely close.
+        @test steps == reference.steps
+        @test solve_time == reference.final_time
+        @test solution == reference.solution
+
+        # And the answer is the one ex16 is known to give.
+        @test solve_time ≈ 0.5 atol = 100 * eps(Float64)
+        @test length(solution) == 2
+        @test all(isfinite, solution)
+
+        @test PETSc.converged_reason(ts) ==
+              PETSc.LibPETSc.TS_CONVERGED_TIME
+        @test PETSc.snes_iterations(ts) >= steps
+
+        PETSc.destroy!(ts)
+        PETSc.destroy(u)
+        PETSc.destroy(jac)
+    end
+
+    @testset "damping sweep, closures and a recorded trajectory" begin
+        # du/dt = [-k 1; -1 -k] u from u(0) = [1, 0], whose solution is
+        # exp(-k t) * [cos t, -sin t]: a spiral that decays at rate k.
+        #
+        # Three things here are what the low-level layer makes awkward. The
+        # callbacks close over `k` directly, so the sweep needs no context
+        # struct, no `pointer_from_objref` and no `GC.@preserve`. The monitor
+        # appends to an ordinary Julia vector, which stays rooted because `ts`
+        # holds the closure. And the whole stepper is built and thrown away
+        # once per parameter, which with hand-written `@cfunction` pointers
+        # means either a context struct mutated between runs or a fresh set of
+        # trampolines each time.
+        dt = 0.005
+        nsteps = 200
+        tfinal = dt * nsteps
+
+        for k in (0.0, 0.5, 2.0)
+            ts = PETSc.TS(petsclib, comm)
+            # Crank-Nicolson: second order, and exactly norm-preserving on the
+            # undamped problem, which a wrong shift in the Jacobian would break.
+            PETSc.set_type!(ts, :cn)
+            PETSc.set_adapt_type!(ts, :none)
+
+            u = PETSc.VecSeq(petsclib, 2)
+            u[1] = PetscScalar(1)
+            u[2] = PetscScalar(0)
+            PETSc.assemble!(u)
+
+            J = PETSc.MatSeqAIJ(petsclib, 2, 2, PetscInt(2))
+            for i in 1:2, j in 1:2
+                J[i, j] = PetscScalar(0)
+            end
+            PETSc.assemble!(J)
+
+            # F(t, u, u_t) = u_t - A(k) u
+            PETSc.set_ifunction!(ts) do F, _ts, _t, x, xdot
+                PETSc.withlocalarray!(
+                    (x, xdot, F);
+                    read = (true, true, false),
+                    write = (false, false, true),
+                ) do xa, xda, Fa
+                    Fa[1] = xda[1] + k * xa[1] - xa[2]
+                    Fa[2] = xda[2] + xa[1] + k * xa[2]
+                end
+                return 0
+            end
+
+            # dF/du + shift dF/du_t = shift*I - A(k)
+            PETSc.set_ijacobian!(ts, J) do A, _P, _ts, _t, _x, _xdot, shift
+                A[1, 1] = PetscScalar(shift + k)
+                A[1, 2] = PetscScalar(-1)
+                A[2, 1] = PetscScalar(1)
+                A[2, 2] = PetscScalar(shift + k)
+                PETSc.assemble!(A)
+                return 0
+            end
+
+            trajectory = NTuple{3, Float64}[]
+            PETSc.set_monitor!(ts) do _ts, step, t, x
+                push!(trajectory, (Float64(t), Float64(x[1]), Float64(x[2])))
+                return 0
+            end
+
+            PETSc.set_time!(ts, 0.0)
+            PETSc.set_timestep!(ts, dt)
+            PETSc.set_max_time!(ts, tfinal)
+            PETSc.solve!(u, ts)
+
+            decay = exp(-k * tfinal)
+            @test u[1] ≈ decay * cos(tfinal) rtol = 1e-3
+            @test u[2] ≈ -decay * sin(tfinal) rtol = 1e-3
+
+            # One monitor call before the first step, one after each of them.
+            @test length(trajectory) == nsteps + 1
+            @test trajectory[1] == (0.0, 1.0, 0.0)
+            @test trajectory[end][1] ≈ tfinal
+            @test trajectory[end][2] ≈ u[1]
+            @test trajectory[end][3] ≈ u[2]
+
+            radii = [hypot(p[2], p[3]) for p in trajectory]
+            if k == 0
+                # Crank-Nicolson on a skew-symmetric right-hand side is a
+                # Cayley transform, so the radius is conserved to round-off.
+                @test all(r -> isapprox(r, 1.0; rtol = 1e-10), radii)
+            else
+                @test all(<(0), diff(radii))
+                @test radii[end] ≈ decay rtol = 1e-3
+            end
+
+            PETSc.destroy!(ts)
+            PETSc.destroy(u)
+            PETSc.destroy(J)
+        end
+    end
+
+    PETSc.finalize(petsclib)
+end

--- a/wrapping/prologue.jl
+++ b/wrapping/prologue.jl
@@ -224,14 +224,43 @@ const CTS = Ptr{Cvoid}
 abstract type AbstractTS{T} end
 
 mutable struct TS{PetscLib} <: AbstractTS{PetscLib}
-    ptr::Ptr{Cvoid}
-    
-    TS{PetscLib}(ptr::Ptr{Cvoid} = C_NULL) where {PetscLib} = new{PetscLib}(ptr)
+    ptr::CTS
+    age::Int
+    rhs_function!::Function
+    rhs_jacobian!::Function
+    ifunction!::Function
+    ijacobian!::Function
+    monitor::Function
+    user_ctx::Any
+    opts::Any
+
+    TS{PetscLib}(
+        ptr::CTS = C_NULL,
+        age::Int = 0,
+        rhs_function!::Function = _ -> error("rhs_function! not defined"),
+        rhs_jacobian!::Function = _ -> error("rhs_jacobian! not defined"),
+        ifunction!::Function = _ -> error("ifunction! not defined"),
+        ijacobian!::Function = _ -> error("ijacobian! not defined"),
+        monitor::Function = _ -> error("monitor not defined"),
+        user_ctx::Any = nothing,
+        opts::Any = nothing,
+    ) where {PetscLib} = new{PetscLib}(
+        ptr,
+        age,
+        rhs_function!,
+        rhs_jacobian!,
+        ifunction!,
+        ijacobian!,
+        monitor,
+        user_ctx,
+        opts,
+    )
 end
 
 # Convenience constructors
-TS(lib::PetscLib) where {PetscLib} = TS{PetscLib}()
-TS(ptr::Ptr{Cvoid}, lib::PetscLib) where {PetscLib} = TS{PetscLib}(ptr)
+TS(lib::PetscLib) where {PetscLib} = TS{PetscLib}(C_NULL, lib.age)
+TS(ptr::CTS, lib::PetscLib, age::Int = lib.age) where {PetscLib} =
+    TS{PetscLib}(ptr, age)
 
 # Conversion methods
 Base.convert(::Type{Ptr{Cvoid}}, v::AbstractTS) = v.ptr


### PR DESCRIPTION
Adds a high-level TS object in `src/ts.jl`, in the a shape similar to `snes.jl` : constructor and some high-level functions.

PETSc.jl had no high-level TS, so people had to write the `@cfunction`, the context struct and the `GC.@preserve` by hand.

Three choices which can be debated in this implementation:

- Options apply in `solve!`, not the constructor, so callbacks attached in between are visible to `TSSetFromOptions`. `PETSc.type(ts)` is `nothing` until the first solve.
- `exact_final_time` defaults to `MATCHSTEP`; PETSc's `UNSPECIFIED` overshoots silently.
- A raising callback is logged and reported as a PETSc failure instead of unwinding into C.

`TSGetSNES`, `TSGetKSP` and `TSSolve` are hand-written: the first two are generated nulling the caller's handle, from the same generator rule behind #254. Fixing that at the root regenerates everything.

The `TS` struct in `src/autowrapped/petsc_library.jl` gains callback and context slots; `wrapping/prologue.jl` carries the same edit so regeneration should reproduce it.

All in all this PR is purely additive and should not break previous use of the TS interface